### PR TITLE
Kubectl fix

### DIFF
--- a/provision-team/provision_aks.sh
+++ b/provision-team/provision_aks.sh
@@ -83,16 +83,6 @@ then
     echo "Cluster AKS:" $clusterName "created successfully..."
 fi
 
-echo "Installing Kubernetes CLI..."
-(
-    set -x
-    type -p kubectl 
-    if [ ! $? == 0 ]; then
-        # The kubectl will be installed in the system an need root priviledges
-        sudo az aks install-cli 1> /dev/null
-    fi
-)
-
 if [ $? == 0 ];
 then
     echo "kubernetes CLI for AKS:" $clusterName "installed successfully..."
@@ -108,5 +98,3 @@ if [ $? == 0 ];
 then
     echo "Credentials for AKS: "$clusterName" retrieved successfully..."
 fi
-
-

--- a/provision-team/setup.sh
+++ b/provision-team/setup.sh
@@ -29,9 +29,8 @@ shift $((OPTIND-1))
 # Check if kubectl is installed or that we can install it
 type -p kubectl
 if [ ! $? == 0 ]; then
-    # we need to install kubectl therefore root is needed
     if [[ ! $EUID == 0 ]]; then
-        echo "The script must run elevated to install kubectl"
+        echo "kubectl not found, install and re-run setup."
         exit 1
     fi
 fi

--- a/provision-vm/proctorVMSetup.sh
+++ b/provision-vm/proctorVMSetup.sh
@@ -12,6 +12,11 @@ sudo curl -O https://storage.googleapis.com/kubernetes-helm/helm-v2.9.1-linux-am
 sudo tar -zxvf helm-v2.9.1-linux-amd64.tar.gz
 sudo mv linux-amd64/helm /usr/local/bin/helm
 
+echo "############### Installing kubectl ###############"
+curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.9.7/bin/linux/amd64/kubectl
+chmod +x ./kubectl
+sudo mv ./kubectl /usr/local/bin/kubectl
+
 echo "############### Installing Dotnet SDK v2.1.4 ###############"
 curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
 sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
@@ -39,6 +44,7 @@ source ~/.bashrc
 
 echo "############### Pulling Openhack-tools from Github ###############"
 sudo git clone https://github.com/Azure-Samples/openhack-devops-proctor.git /home/azureuser/openhack-devops-proctor
+sudo chown azureuser -R ./openhack-devops-proctor
 
 echo "############### Install Powershell Core and AzureRM modules "###############
 # https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-powershell-core-on-linux?view=powershell-6#ubuntu-1604

--- a/provision-vm/proctorVMSetup.sh
+++ b/provision-vm/proctorVMSetup.sh
@@ -72,3 +72,4 @@ Import-Module AzureRM.Netcore
 Import-Module AzureRM.Profile.Netcore
 # Exit out of pwsh so bash can complete
 exit
+


### PR DESCRIPTION
## Purpose
When kubectl is not installed on the proctor VM, the script will fail to install `kubectl` after the AKS even though the setup script was run as `sudo`.  This changes the kubectl dependency to install as a prerequisite.

VM Provision script fixes:
- removes prompts from the `mssql` package install
- sets proper permissions to the cloned directory