### PR TITLE
Fix and update the Proctor VM, documentation

### DIFF
--- a/provision-team/README.md
+++ b/provision-team/README.md
@@ -4,8 +4,8 @@
 
 ## Pre-requisites
 
-- Access to [MyDriving github repository](https://github.com/Azure-Samples/openhack-devops)
-- Generete ssh key to get openhack-team-cli https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/
+- Access to [MyDriving github repository](https://github.com/Azure-Samples/openhack-devops-team)
+- Generate ssh key to get openhack-team-cli https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/
 - [Helm](https://docs.helm.sh/using_helm/#installing-helm)
 - Azure [AZ cli](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
 - [.net core 2.0.4](https://www.microsoft.com/net/download/) [Linux install](https://www.microsoft.com/net/download/linux-package-manager/ubuntu16-04/sdk-current)
@@ -26,4 +26,7 @@
 
 An example command to provision might look like the following:
 
-`./setup.sh -i e57679d8-3a04-4828-97e6-35169ea30349 -l eastus -n devopsoh`
+`./setup.sh -i 9d05a3cd-f0f4-439f-883e-c855e054 -l eastus -n devopsoh`
+
+If running from the proctor VM, please first execute:
+`sudo chown azureuser -R ./openhack-devops-proctor`

--- a/provision-vm/azuredeploy.json
+++ b/provision-vm/azuredeploy.json
@@ -14,12 +14,6 @@
                 "description": "Username for the Virtual Machine."
             }
         },
-        "adminPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Password for the Virtual Machine."
-            }
-        },
         "dnsNameForPublicIP": {
             "type": "string",
             "metadata": {
@@ -33,22 +27,30 @@
                 "description": "VM size for the Docker host."
             }
         },
+        "sshKeyData": {
+            "type": "string",
+            "metadata": {
+              "description": "SSH rsa public key file as a string."
+            }
+        },
         "ubuntuOSVersion": {
             "type": "string",
-            "defaultValue": "16.04.0-LTS",
+            "defaultValue": "16.04-DAILY-LTS",
             "metadata": {
                 "description": "The Ubuntu version for deploying the Docker containers. This will pick a fully patched image of this given Ubuntu version. Allowed values: 14.04.4-LTS, 15.10, 16.04.0-LTS"
             },
             "allowedValues": [
-                "14.04.4-LTS",
-                "15.10",
-                "16.04.0-LTS"
+                "14.04.5-LTS",
+                "16.04-DAILY-LTS",
+                "16.04-LTS",
+                "18.04-LTS"
             ]
         }
     },
     "variables": {
         "imagePublisher": "Canonical",
         "imageOffer": "UbuntuServer",
+        "skuversion": "16.04.201805220",
         "OSDiskName": "osdiskfordockersimple",
         "nicName": "proctorVMNic",
         "extensionName": "DockerExtension",
@@ -62,6 +64,7 @@
         "vmName": "proctorVM",
         "virtualNetworkName": "proctorVMVNET",
         "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+        "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
         "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]"
     },
     "resources": [
@@ -150,14 +153,24 @@
                 "osProfile": {
                     "computerName": "[variables('vmName')]",
                     "adminUsername": "[parameters('adminUsername')]",
-                    "adminPassword": "[parameters('adminPassword')]"
+                    "linuxConfiguration": {
+                        "disablePasswordAuthentication": true,
+                        "ssh": {
+                          "publicKeys": [
+                            {
+                              "path": "[variables('sshKeyPath')]",
+                              "keyData": "[parameters('sshKeyData')]"
+                            }
+                          ]
+                        }
+                      }
                 },
                 "storageProfile": {
                     "imageReference": {
                         "publisher": "[variables('imagePublisher')]",
                         "offer": "[variables('imageOffer')]",
                         "sku": "[parameters('ubuntuOSVersion')]",
-                        "version": "latest"
+                        "version": "[variables('skuversion')]"
                     },
                     "osDisk": {
                         "name": "osdisk1",
@@ -209,7 +222,7 @@
                 "autoUpgradeMinorVersion": true,
                 "settings": {
                     "fileUris": [
-                        "https://raw.githubusercontent.com/Azure-Samples/openhack-devops-proctor/master/provision-vm/proctorVMSetup.sh"
+                        "https://raw.githubusercontent.com/Azure-Samples/openhack-devops-proctor/fixvmscript/provision-vm/proctorVMSetup.sh"
                     ],
                     "commandToExecute": "sh proctorVMSetup.sh"
                 }

--- a/provision-vm/azuredeploy.json
+++ b/provision-vm/azuredeploy.json
@@ -222,7 +222,7 @@
                 "autoUpgradeMinorVersion": true,
                 "settings": {
                     "fileUris": [
-                        "https://raw.githubusercontent.com/Azure-Samples/openhack-devops-proctor/fixvmscript/provision-vm/proctorVMSetup.sh"
+                        "https://raw.githubusercontent.com/Azure-Samples/openhack-devops-proctor/master/provision-vm/proctorVMSetup.sh"
                     ],
                     "commandToExecute": "sh proctorVMSetup.sh"
                 }

--- a/provision-vm/azuredeploy.parameters.json
+++ b/provision-vm/azuredeploy.parameters.json
@@ -8,14 +8,11 @@
       "adminUsername": {
         "value": "VM ADMIN USERNAME"
       },
-      "adminPassword": {
-        "value": "ADMIN PASSWORD"
-      },
       "dnsNameForPublicIP": {
         "value": "DNS NAME FOR PUBLIC IP"
       },
       "ubuntuOSVersion": {
-        "value": "16.04.0-LTS"
+        "value": "16.04-DAILY-LTS"
       }
     }
   }

--- a/provision-vm/deploy.ps1
+++ b/provision-vm/deploy.ps1
@@ -1,8 +1,7 @@
 Param(
      [string] [Parameter(Mandatory=$true)] $Location,
      [string] [parameter(Mandatory=$true)] $Number,
-     [string] [parameter(Mandatory=$true)] $PublicKey,
-     [string] [parameter(Mandatory=$true)] $AdminPassword
+     [string] [parameter(Mandatory=$true)] $PublicKey
 )
 
 $num = $Number #"116"
@@ -31,4 +30,4 @@ New-AzureRmStorageAccount -Name $vmStorageName -ResourceGroupName $RGNameVM -Loc
 
 $vmTemplate = $PSScriptRoot + '\azuredeploy.json'
 
-New-AzureRmResourceGroupDeployment -Name "ProctorVMDeployment" -ResourceGroup $RGNameVM -Templatefile $vmTemplate -StorageAccountName $vmStorageName -adminUsername $AdminUser -adminPassword (ConvertTo-SecureString $adminPassword -AsPlainText -Force) -dnsNameForPublicIP $proctorVMName -ubuntuOSVersion "16.04.0-LTS"
+New-AzureRmResourceGroupDeployment -Name "ProctorVMDeployment" -ResourceGroup $RGNameVM -Templatefile $vmTemplate -StorageAccountName $vmStorageName -adminUsername $AdminUser  -dnsNameForPublicIP $proctorVMName -sshKeyData $PublicKey

--- a/provision-vm/proctorVMSetup.sh
+++ b/provision-vm/proctorVMSetup.sh
@@ -22,7 +22,6 @@ curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microso
 sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
 sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-xenial-prod xenial main" > /etc/apt/sources.list.d/dotnetdev.list'
 
-sudo apt-get install -y apt-transport-https
 sudo apt-get update
 sudo apt-get install -y dotnet-sdk-2.1.4
 
@@ -36,7 +35,7 @@ echo "############### Installing SQL cmd line tools ###############"
 curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | sudo tee /etc/apt/sources.list.d/msprod.list
 sudo apt-get update
-sudo apt-get install -y mssql-tools unixodbc-dev
+sudo ACCEPT_EULA=Y apt-get install -y mssql-tools unixodbc-dev
 echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile
 
 #pick up changes to bash profile
@@ -61,15 +60,11 @@ echo "############### Install Powershell Core and AzureRM modules "#############
 sudo apt-get install -y powershell
 # Start PowerShell and install AzureRm modules
 # https://docs.microsoft.com/en-us/powershell/azure/install-azurermps-maclinux?view=azurermps-6.0.0
-sudo pwsh
 
 #Change trust policy on powershell gallery to Trusted for unattended install
-Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+sudo pwsh -command "& {Set-PSRepository -Name PSGallery -InstallationPolicy Trusted}"
 
 #Install AzureRM Modules
-Install-Module AzureRM.NetCore
-Import-Module AzureRM.Netcore
-Import-Module AzureRM.Profile.Netcore
-# Exit out of pwsh so bash can complete
-exit
-
+sudo pwsh -command "& {Install-Module AzureRM.NetCore}"
+sudo pwsh -command "& {Import-Module AzureRM.Netcore}"
+sudo pwsh -command "& {Import-Module AzureRM.Profile.Netcore}"

--- a/provision-vm/proctorVMSetup.sh
+++ b/provision-vm/proctorVMSetup.sh
@@ -5,7 +5,6 @@ echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO 
 sudo apt-key adv --keyserver packages.microsoft.com --recv-keys 52E16F86FEE04B979B07E28DB02C46DF417A0893
 sudo apt-get install -y apt-transport-https
 sudo apt-get update
-sudo apt-get install -y azure-cli=2.0.31-1~xenial
 
 echo "############### Installing Helm v2.9.1 ###############"
 sudo curl -O https://storage.googleapis.com/kubernetes-helm/helm-v2.9.1-linux-amd64.tar.gz
@@ -69,5 +68,6 @@ sudo pwsh -command "& {Install-Module AzureRM.NetCore}"
 sudo pwsh -command "& {Import-Module AzureRM.Netcore}"
 sudo pwsh -command "& {Import-Module AzureRM.Profile.Netcore}"
 
+sudo apt-get install -y azure-cli=2.0.31-1~xenial
+
 sudo apt-get upgrade -y
-sudo reboot

--- a/provision-vm/proctorVMSetup.sh
+++ b/provision-vm/proctorVMSetup.sh
@@ -42,6 +42,7 @@ source ~/.bashrc
 
 echo "############### Pulling Openhack-tools from Github ###############"
 sudo git clone https://github.com/Azure-Samples/openhack-devops-proctor.git /home/azureuser/openhack-devops-proctor
+# This doesn't actually take effect for some reason and have to run same command after login.
 sudo chown azureuser -R ./openhack-devops-proctor
 
 echo "############### Install Powershell Core and AzureRM modules "###############
@@ -68,6 +69,7 @@ sudo pwsh -command "& {Install-Module AzureRM.NetCore}"
 sudo pwsh -command "& {Import-Module AzureRM.Netcore}"
 sudo pwsh -command "& {Import-Module AzureRM.Profile.Netcore}"
 
+# Installing this at the end because for some reason it doesn't take effect when immediately after the AZ setup
 sudo apt-get install -y azure-cli=2.0.31-1~xenial
 
 sudo apt-get upgrade -y

--- a/provision-vm/proctorVMSetup.sh
+++ b/provision-vm/proctorVMSetup.sh
@@ -5,7 +5,6 @@ echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO 
 sudo apt-key adv --keyserver packages.microsoft.com --recv-keys 52E16F86FEE04B979B07E28DB02C46DF417A0893
 sudo apt-get install -y apt-transport-https
 sudo apt-get update
-sleep 5
 sudo apt-get install -y azure-cli=2.0.31-1~xenial
 
 echo "############### Installing Helm v2.9.1 ###############"
@@ -70,6 +69,5 @@ sudo pwsh -command "& {Install-Module AzureRM.NetCore}"
 sudo pwsh -command "& {Import-Module AzureRM.Netcore}"
 sudo pwsh -command "& {Import-Module AzureRM.Profile.Netcore}"
 
-sudo apt-get full-upgrade -y
-sudo apt-get autoremove -y
+sudo apt-get upgrade -y
 sudo reboot

--- a/provision-vm/proctorVMSetup.sh
+++ b/provision-vm/proctorVMSetup.sh
@@ -5,6 +5,7 @@ echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO 
 sudo apt-key adv --keyserver packages.microsoft.com --recv-keys 52E16F86FEE04B979B07E28DB02C46DF417A0893
 sudo apt-get install -y apt-transport-https
 sudo apt-get update
+sleep 5
 sudo apt-get install -y azure-cli=2.0.31-1~xenial
 
 echo "############### Installing Helm v2.9.1 ###############"
@@ -68,3 +69,7 @@ sudo pwsh -command "& {Set-PSRepository -Name PSGallery -InstallationPolicy Trus
 sudo pwsh -command "& {Install-Module AzureRM.NetCore}"
 sudo pwsh -command "& {Import-Module AzureRM.Netcore}"
 sudo pwsh -command "& {Import-Module AzureRM.Profile.Netcore}"
+
+sudo apt-get full-upgrade -y
+sudo apt-get autoremove -y
+sudo reboot

--- a/provision-vm/readme.md
+++ b/provision-vm/readme.md
@@ -13,7 +13,7 @@ Login-AzureRmAccount
 For Ubuntu it will be:
 
 ```shell
-pwsh
+sudo pwsh
 Connect-AzureRmAccount
 ```
 
@@ -24,6 +24,7 @@ Run this from the root of the `provision-vm` folder.
 $YOUR_LOCATION = 'eastus'
 $YOUR_NUMBER = '' # 3940
 $YOUR_PUBLIC_KEY = '' # ssh-rsa AAAAB3NzaC1yc2EAAAADA... @microsoft.com
-$YOUR_PASSWORD = 'ComplexPassw0rdyo!'
-.\deploy.ps1 -Location $YOUR_LOCATION -Number $YOUR_NUMBER -PublicKey $YOUR_PUBLIC_KEY -AdminPassword $YOUR_PASSWORD
+.\deploy.ps1 -Location $YOUR_LOCATION -Number $YOUR_NUMBER -PublicKey $YOUR_PUBLIC_KEY
 ```
+
+After provisioning, login to the VM with the public IP address attached to the VM and the SSH key provided.


### PR DESCRIPTION
## Purpose
The proctor VM will not complete as-is due to some issues with the provisioning script.
- Fixed provisioning, verified all tools working upon login
- Updated template to use the latest version of LTS to not have to patch as much, auto update security patches in the script
- Change the connection mechanism to use SSH key instead of a password for the VM