### PR TITLE
fixed sqlcmd path

### DIFF
--- a/provision-team/configure_sql.sh
+++ b/provision-team/configure_sql.sh
@@ -105,7 +105,7 @@ kubectl apply -f $relativeSaveLocation"/sql-secret-$teamName.yaml"
 az sql server firewall-rule create -n allow-create-schema -g $resourceGroupName -s $sqlServer --start-ip-address 0.0.0.0 --end-ip-address 255.255.255.254
 
 #Create schema in db
-sqlcmd -U $sqlServerUsername -P $sqlPassword -S $sqlServerFQDN -d $sqlDBName -i ./MYDrivingDB.sql -e
+/opt/mssql-tools/bin/sqlcmd -U $sqlServerUsername -P $sqlPassword -S $sqlServerFQDN -d $sqlDBName -i ./MYDrivingDB.sql -e
 
 #Remove firewall rule
 az sql server firewall-rule delete -n allow-create-schema -g $resourceGroupName -s $sqlServer


### PR DESCRIPTION
Workaround to execute sqlcmd: 

Append the full path to **_sqlcmd_** call. 

**FROM:**
sqlcmd -U $sqlServerUsername -P $sqlPassword -S $sqlServerFQDN -d $sqlDBName -i ./MYDrivingDB.sql -e
**TO:**
/opt/mssql-tools/bin/sqlcmd -U $sqlServerUsername -P $sqlPassword -S $sqlServerFQDN -d $sqlDBName -i ./MYDrivingDB.sql -e