### PR TITLE
Fix kubernetes sql secrets

### DIFF
--- a/provision-team/cleanup_environment.sh
+++ b/provision-team/cleanup_environment.sh
@@ -31,10 +31,10 @@ if [ -f $HOME/.azure/aksServicePrincipal.json ]; then
 fi
 
 # 2- Copy the kubeconfig file
-# if [ -f $HOME/.kube/config ]; then
-#     mv $HOME/.kube/config $HOME/team-env/kubeconfig-$teamName
-#     echo "The kubeconfig file has been move to $HOME/team-env/kubeconfig-$teamName"
-# fi
+if [ -f $HOME/.kube/config ]; then
+    cp $HOME/.kube/config $HOME/team-env/kubeconfig-$teamName
+    echo "Copied the kubeconfig file to $HOME/team-env/kubeconfig-$teamName"
+fi
 
 # 3- Delete the working directory
 rm -rf ./test_fetch_build

--- a/provision-team/configure_sql.sh
+++ b/provision-team/configure_sql.sh
@@ -88,9 +88,9 @@ sqlServerFQDN=$(az keyvault secret show --vault-name $keyVaultName --name sqlSer
 sqlPassword=$(az keyvault secret show --vault-name $keyVaultName --name sqlServerPassword -o tsv --query value)
 
 # Base64 encode the values are required for K8s secrets
-sqlServerFQDNbase64=$(echo $sqlServerFQDN | base64)
-sqlPasswordbase64=$(echo $sqlPassword | base64)
-sqlUserbase64=$(echo $sqlServerUsername | base64)
+sqlServerFQDNbase64=$(echo -n $sqlServerFQDN | base64)
+sqlPasswordbase64=$(echo -n $sqlPassword | base64)
+sqlUserbase64=$(echo -n $sqlServerUsername | base64)
 
 # Replace the secrets file with encoded values and create the secret on the cluster
 cat "./sql-secret.yaml" \

--- a/provision-team/provision_sql_mobileapp.sh
+++ b/provision-team/provision_sql_mobileapp.sh
@@ -135,7 +135,7 @@ echo "$(tput setaf 3)Adding values to Key Vault...$(tput sgr 0)"
     sqlServerFQDN=$(az sql server show -g $resourceGroupName -n $sqlServerName --query "fullyQualifiedDomainName" --output tsv)
     az keyvault secret set --vault-name $keyVaultName --name 'sqlServerName' --value $sqlServerName
     az keyvault secret set --vault-name $keyVaultName --name 'sqlDBName' --value $sqlDBName
-    az keyvault secret set --vault-name $keyVaultName --name 'sqlServerUsername' --value $sqlServerUsername
+    az keyvault secret set --vault-name $keyVaultName --name 'sqlServerUsername' --value $sqlServerUsername'@'$sqlServerFQDN
     az keyvault secret set --vault-name $keyVaultName --name 'sqlServerPassword' --value $sqlServerPassword
     az keyvault secret set --vault-name $keyVaultName --name 'sqlServerFQDN' --value $sqlServerFQDN
     az keyvault secret set --vault-name $keyVaultName --name 'mobileAppName' --value $mobileAppName


### PR DESCRIPTION
## Purpose
- Fix the sql server secrets to not have a new line when they are base64 encoded, causing the api-user database connection to fail
- Make the sql username secret have the `@` sqlserverFQDN at the end 
- Add back in the copy of kube config file for the cleanup script