### PR TITLE
Remove the host code for automation

### DIFF
--- a/leaderboard/api/Leaderboard/RestAPI.cs
+++ b/leaderboard/api/Leaderboard/RestAPI.cs
@@ -35,7 +35,7 @@ namespace Leaderboard
         /// <param name="log"></param>
         /// <returns></returns>
         [FunctionName("ReportStatus")]
-        public static async Task<IActionResult> ReportStatus([HttpTrigger(AuthorizationLevel.Function, "post", Route = null)]HttpRequest req, TraceWriter log)
+        public static async Task<IActionResult> ReportStatus([HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = null)]HttpRequest req, TraceWriter log)
         {
             try
             {
@@ -92,7 +92,7 @@ namespace Leaderboard
         }
 
         [FunctionName("GetTeamsStatus")]
-        public static async Task<IActionResult> GetTeamsStatus([HttpTrigger(AuthorizationLevel.Function, "get", Route = null)]HttpRequest req, TraceWriter log)
+        public static async Task<IActionResult> GetTeamsStatus([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)]HttpRequest req, TraceWriter log)
         {
             using (var scope = Container.BeginLifetimeScope())
             {

--- a/leaderboard/api/Leaderboard/RestAPI.cs
+++ b/leaderboard/api/Leaderboard/RestAPI.cs
@@ -42,7 +42,7 @@ namespace Leaderboard
                 // Get Downtime Report
                 using (var scope = Container.BeginLifetimeScope())
                 {
-                    var service = scope.Resolve<DocumentService>();
+                    var service = scope.Resolve<IDocumentService>();
 
                     var requestBody = new StreamReader(req.Body).ReadToEnd();
                     log.Info(requestBody);
@@ -98,7 +98,7 @@ namespace Leaderboard
             {
                 try
                 {
-                    var service = scope.Resolve<DocumentService>();
+                    var service = scope.Resolve<IDocumentService>();
                     // Get Openhack Start/End time.
                     var openhack = await service.GetDocumentAsync<Openhack>();
                     // Get Team list

--- a/provision-proctor/build_deploy_web.sh
+++ b/provision-proctor/build_deploy_web.sh
@@ -6,13 +6,18 @@ IFS=$'\n\t'
 # -o: prevents errors in a pipeline from being masked
 # IFS new value is less likely to cause confusing bugs when looping arrays or arguments (e.g. $@)
 
-usage() { echo "Usage: build_deploy_web.sh -m <proctor name> -d <dnsURL>" 1>&2; exit 1; }
+usage() { echo "Usage: build_deploy_web.sh -u <proctorNumber> -m <proctor name> -d <dnsURL>" 1>&2; exit 1; }
 
+declare proctorNumber=""
 declare proctorName=""
+declare dnsURL=""
 
 # Initialize parameters specified from command line
-while getopts ":m:d:" arg; do
+while getopts ":u:m:d:" arg; do
     case "${arg}" in
+        u)
+            proctorNumber=${OPTARG}
+        ;;
         m)
             proctorName=${OPTARG}
         ;;
@@ -23,14 +28,6 @@ while getopts ":m:d:" arg; do
 done
 shift $((OPTIND-1))
 
-
-# if [[ -z "$resourceGroupName" ]]; then
-#     echo "This script will look for an existing resource group, otherwise a new one will be created "
-#     echo "You can create new resource groups with the CLI using: az group create "
-#     echo "Enter a resource group name"
-#     read resourceGroupName
-#     [[ "${resourceGroupName:?}" ]]
-# fi
 
 if [[ -z "$proctorName" ]]; then
     echo "Enter a team name for the helm chart values filename:"
@@ -49,8 +46,8 @@ if [ -z "$proctorName" ] || [ -z "$dnsURL" ]; then
     usage
 fi
 
-declare resourceGroupName="${proctorName}-rg"
-declare registryName="${proctorName}acr"
+declare resourceGroupName="${proctorName}${proctorNumber}-rg"
+declare registryName="${proctorName}${proctorNumber}acr"
 
 #DEBUG
 echo $resourceGroupName

--- a/provision-proctor/build_deploy_web.sh
+++ b/provision-proctor/build_deploy_web.sh
@@ -6,18 +6,13 @@ IFS=$'\n\t'
 # -o: prevents errors in a pipeline from being masked
 # IFS new value is less likely to cause confusing bugs when looping arrays or arguments (e.g. $@)
 
-usage() { echo "Usage: build_deploy_web.sh -u <proctorNumber> -m <proctor name> -d <dnsURL>" 1>&2; exit 1; }
+usage() { echo "Usage: build_deploy_web.sh -m <proctor name> -d <dnsURL>" 1>&2; exit 1; }
 
-declare proctorNumber=""
 declare proctorName=""
-declare dnsURL=""
 
 # Initialize parameters specified from command line
-while getopts ":u:m:d:" arg; do
+while getopts ":m:d:" arg; do
     case "${arg}" in
-        u)
-            proctorNumber=${OPTARG}
-        ;;
         m)
             proctorName=${OPTARG}
         ;;
@@ -28,6 +23,14 @@ while getopts ":u:m:d:" arg; do
 done
 shift $((OPTIND-1))
 
+
+# if [[ -z "$resourceGroupName" ]]; then
+#     echo "This script will look for an existing resource group, otherwise a new one will be created "
+#     echo "You can create new resource groups with the CLI using: az group create "
+#     echo "Enter a resource group name"
+#     read resourceGroupName
+#     [[ "${resourceGroupName:?}" ]]
+# fi
 
 if [[ -z "$proctorName" ]]; then
     echo "Enter a team name for the helm chart values filename:"
@@ -46,8 +49,8 @@ if [ -z "$proctorName" ] || [ -z "$dnsURL" ]; then
     usage
 fi
 
-declare resourceGroupName="${proctorName}${proctorNumber}-rg"
-declare registryName="${proctorName}${proctorNumber}acr"
+declare resourceGroupName="${proctorName}-rg"
+declare registryName="${proctorName}acr"
 
 #DEBUG
 echo $resourceGroupName

--- a/provision-proctor/setup.sh
+++ b/provision-proctor/setup.sh
@@ -118,7 +118,7 @@ declare clusterName="${proctorName}${proctorNumber}aks"
 declare cosmosDBName="${proctorName}${proctorNumber}db"
 declare storageAccount="${proctorName}${proctorNumber}sa"
 declare functionAppName="${proctorName}${proctorNumber}fun"
-declare apiUrl="https://"$functionAppName".azurewebsites.net"
+declare apiUrl="https://"$functionAppName".azurewebsites.net/api/ReportStatus"
 
 echo "=========================================="
 echo " VARIABLES"

--- a/provision-proctor/setup.sh
+++ b/provision-proctor/setup.sh
@@ -195,8 +195,8 @@ bash ../provision-team/deploy_ingress_dns.sh -s . -l $resourceGroupLocation -n $
 dnsURL='akstraefik'${proctorName}'.'$resourceGroupLocation'.cloudapp.azure.com'
 echo -e "DNS URL for "${proctorName}" is:\n"$dnsURL
 
-echo "9-Build and deploy sentinel to AKS  (bash ./build_deploy_sentinel.sh -r $resourceGroupProctor -g $registryName -n ${teamName} -e $totalTeams -l $location -a $apiUrl)"
-bash ./build_deploy_sentinel.sh -r $resourceGroupProctor -g $registryName -n ${teamName} -e $totalTeams -l $resourceGroupLocation -a $apiUrl
+echo "9-Build and deploy sentinel to AKS  (bash ./build_deploy_sentinel.sh -r $resourceGroupProctor -g $registryName -n $teamName -e $totalTeams -l $resourceGroupLocation -a $apiUrl)"
+bash ./build_deploy_sentinel.sh -r $resourceGroupProctor -g $registryName -n $teamName -e $totalTeams -l $resourceGroupLocation -a $apiUrl
 
 echo "10-Build and deploy leaderboard website to AKS  (bash ./build_deploy_web.sh -m $proctorName -d <dnsURL>)"
 bash ./build_deploy_web.sh -m $proctorName -d $dnsURL

--- a/provision-proctor/setup.sh
+++ b/provision-proctor/setup.sh
@@ -78,17 +78,17 @@ if [[ -z "$resourceGroupLocation" ]]; then
 fi
 
 if [[ -z "$proctorName" ]]; then
-    echo "Enter a team name to be used in app provisioning:"
+    echo "Enter a proctor name to be used to provision proctor resources:"
     read proctorName
 fi
 
 if [[ -z "$teamName" ]]; then
-    echo "Enter a team name to be used in app provisioning:"
+    echo "Enter the base team name used for the already provisioned team environments:"
     read teamName
 fi
 
 if [[ -z "$totalTeams" ]]; then
-    echo "Enter the total number of teams provisioned:"
+    echo "Enter the total number of already provisioned team environments:"
     read totalTeams
 fi
 
@@ -186,20 +186,20 @@ echo "6-Provision AKS  (bash ./provision_aks.sh -i $subscriptionId -g $resourceG
 bash ../provision-team/provision_aks.sh -i $subscriptionId -g $resourceGroupProctor -c $clusterName -l $resourceGroupLocation
 
 echo "7-Set AKS/ACR permissions  (bash ./provision_aks_acr_auth.sh -i $subscriptionId -g $resourceGroupProctor -c $clusterName -r $registryName -l $resourceGroupLocation)"
-bash ../provision-team/provision_aks_acr_auth.sh -i $subscriptionId -g $resourceGroupProctor -c $clusterName -r $registryName -l $resourceGroupLocation
+bash ../provision-team/provision_aks_acr_auth.sh -i $subscriptionId -g $resourceGroupProctor -c $clusterName -r $registryName -l $resourceGroupLocation -n ${proctorName}${proctorNumber}
 
-echo "8-Deploy ingress  (bash ./deploy_ingress_dns.sh -s ./test_fetch_build -l $resourceGroupLocation -n ${proctorName})"
-bash ../provision-team/deploy_ingress_dns.sh -s . -l $resourceGroupLocation -n ${proctorName}
+echo "8-Deploy ingress  (bash ./deploy_ingress_dns.sh -s . -l $resourceGroupLocation -n ${proctorName}${proctorNumber})"
+bash ../provision-team/deploy_ingress_dns.sh -s . -l $resourceGroupLocation -n ${proctorName}${proctorNumber}
 
 # Save the public DNS address to be provisioned in the helm charts for each service
-dnsURL='akstraefik'${proctorName}'.'$resourceGroupLocation'.cloudapp.azure.com'
-echo -e "DNS URL for "${proctorName}" is:\n"$dnsURL
+dnsURL='akstraefik'${proctorName}${proctorNumber}'.'$resourceGroupLocation'.cloudapp.azure.com'
+echo -e "DNS URL for "${proctorName}${proctorNumber}" is:\n"$dnsURL
 
 echo "9-Build and deploy sentinel to AKS  (bash ./build_deploy_sentinel.sh -r $resourceGroupProctor -g $registryName -n $teamName -e $totalTeams -l $resourceGroupLocation -a $apiUrl)"
 bash ./build_deploy_sentinel.sh -r $resourceGroupProctor -g $registryName -n $teamName -e $totalTeams -l $resourceGroupLocation -a $apiUrl
 
-echo "10-Build and deploy leaderboard website to AKS  (bash ./build_deploy_web.sh -m $proctorName -d <dnsURL>)"
-bash ./build_deploy_web.sh -u $proctorNumber -m $proctorName -d $dnsURL
+echo "10-Build and deploy leaderboard website to AKS  (bash ./build_deploy_web.sh -m ${proctorName}${proctorNumber} -d <dnsURL>)"
+bash ./build_deploy_web.sh -m ${proctorName}${proctorNumber} -d $dnsURL
 
 echo "11-Clean the working environment"
-bash ../provision-team/cleanup_environment.sh -t ${proctorName}
+bash ../provision-team/cleanup_environment.sh -t ${proctorName}${proctorNumber}

--- a/provision-proctor/setup.sh
+++ b/provision-proctor/setup.sh
@@ -199,7 +199,7 @@ echo "9-Build and deploy sentinel to AKS  (bash ./build_deploy_sentinel.sh -r $r
 bash ./build_deploy_sentinel.sh -r $resourceGroupProctor -g $registryName -n $teamName -e $totalTeams -l $resourceGroupLocation -a $apiUrl
 
 echo "10-Build and deploy leaderboard website to AKS  (bash ./build_deploy_web.sh -m $proctorName -d <dnsURL>)"
-bash ./build_deploy_web.sh -m $proctorName -d $dnsURL
+bash ./build_deploy_web.sh -u $proctorNumber -m $proctorName -d $dnsURL
 
 echo "11-Clean the working environment"
 bash ../provision-team/cleanup_environment.sh -t ${proctorName}


### PR DESCRIPTION
I run through the deployment process. 

I fix several things to prevent automation. 


# TODO 

The proctor-environment deployment script asks me the name of team name during the deployment process. I can't find it. 

Please merge this and try to deploy proctor environment. 

# Process

1. Teams Deployments
2. Edit these files to have valid data.

https://github.com/Azure-Samples/openhack-devops-proctor/blob/master/leaderboard/api/CLI/team_service_config.json
and 
https://github.com/Azure-Samples/openhack-devops-proctor/blob/master/leaderboard/web/src/environments/environment.prod.ts

3. deploy Proctor environment setup script

For more detail, please ask David. :)