### PR TITLE
fix: endpoint names 

### DIFF
--- a/leaderboard/api/CLI/CLI.csproj
+++ b/leaderboard/api/CLI/CLI.csproj
@@ -21,7 +21,7 @@
     <None Update="openhack.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="services.json">
+    <None Update="team_service_config.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/leaderboard/api/CLI/Program.cs
+++ b/leaderboard/api/CLI/Program.cs
@@ -148,21 +148,20 @@ namespace CLI
             {
                 teamNum++;
                 var endpoint = element.Value.Value<JToken>("endpoint");
-                var newId = String.Format("{0:D2}", teamNum);
                 var team = new Team
                 {
-                    Id = newId,
+                    Id = element.Key,
                     Name = element.Key,
                     Challenges = GetInitialChallenges(),
                     Services = new Service[] {
                         new Service {
-                            Id = $"{newId}01"
+                            Id = $"{element.Key}user"
                         },
                         new Service {
-                            Id = $"{newId}02"
+                            Id = $"{element.Key}trips"
                         },
                         new Service {
-                            Id = $"{newId}03"
+                            Id = $"{element.Key}poi"
                         }
                     },
                     Score = 0                
@@ -172,20 +171,20 @@ namespace CLI
                     new Service
                     {
                         Id = $"{team.Id}01",
-                        Name = $"{team.Name}USER",
-                        Uri = $"{endpoint}/api/healthcheck/user"
+                        Name = $"{team.Name}user",
+                        Uri = $"{endpoint}/user"
                     },
                     new Service
                     {
                         Id = $"{team.Id}02",
-                        Name = $"{team.Name}TRIPS",
-                        Uri = $"{endpoint}/api/healthcheck/trips"
+                        Name = $"{team.Name}trips",
+                        Uri = $"{endpoint}/trips"
                     },
                     new Service
                     {
                         Id = $"{team.Id}03",
-                        Name = $"{team.Name}POI",
-                        Uri = $"{endpoint}/api/healthcheck/poi"
+                        Name = $"{team.Name}poi",
+                        Uri = $"{endpoint}/poi"
                     }
                 };
                 var histories = new History[] { };

--- a/leaderboard/api/CLI/Program.cs
+++ b/leaderboard/api/CLI/Program.cs
@@ -170,19 +170,19 @@ namespace CLI
                 {
                     new Service
                     {
-                        Id = $"{team.Id}01",
+                        Id = $"{team.Id}user",
                         Name = $"{team.Name}user",
                         Uri = $"{endpoint}/user"
                     },
                     new Service
                     {
-                        Id = $"{team.Id}02",
+                        Id = $"{team.Id}trips",
                         Name = $"{team.Name}trips",
                         Uri = $"{endpoint}/trips"
                     },
                     new Service
                     {
-                        Id = $"{team.Id}03",
+                        Id = $"{team.Id}poi",
                         Name = $"{team.Name}poi",
                         Uri = $"{endpoint}/poi"
                     }

--- a/leaderboard/api/SharedLibrary/DocumentService.cs
+++ b/leaderboard/api/SharedLibrary/DocumentService.cs
@@ -62,25 +62,24 @@ namespace Services
 
         public async Task<T> GetServiceAsync<T>(string id) where T : IDocument
         {
-            var docUri = UriFactory.CreateDocumentUri(databaseId, typeof(T).Name, id);
-            var doc = await client.ReadDocumentAsync<T>(docUri);
-            return doc.Document;
+            //var docUri = UriFactory.CreateDocumentUri(databaseId, typeof(T).Name, id);
+            //var doc = await client.ReadDocumentAsync<T>(docUri);
+            //return doc.Document;
 
-            //    var uri = UriFactory.CreateDocumentCollectionUri(databaseId, typeof(T).Name);
-            //    var query = client.CreateDocumentQuery<T>(
-            //        uri,
-            //        new FeedOptions { EnableCrossPartitionQuery = true })
-            //        .Where(f => f.Id == id)
-            //        .AsEnumerable<T>();
-            //    List<T> list = new List<T>();
-            //   foreach (var i in query)
-            //    {
-            //        list.Add(i);
-            //    }
-            //    //            var result = query.FirstOrDefault<T>();
-            //    var list2 = list;
-            //    return list.FirstOrDefault<T>();
-            //
+            var uri = UriFactory.CreateDocumentCollectionUri(databaseId, typeof(T).Name);
+            var query = client.CreateDocumentQuery<T>(
+                uri,
+                new FeedOptions { EnableCrossPartitionQuery = true })
+                .Where(f => f.Id == id)
+                .AsEnumerable<T>();
+            List<T> list = new List<T>();
+            foreach (var i in query)
+            {
+                list.Add(i);
+            }
+            var list2 = list;
+            return list.FirstOrDefault<T>();
+
         }
 
         public async Task<IList<T>> GetDocumentsAsync<T>(string id) where T :IDocument

--- a/leaderboard/api/SharedLibrary/DocumentService.cs
+++ b/leaderboard/api/SharedLibrary/DocumentService.cs
@@ -46,7 +46,7 @@ namespace Services
         public async Task<IList<T>> GetAllDocumentsAsync<T>()
         {
             var query = client.CreateDocumentQuery<T>(
-                UriFactory.CreateDocumentCollectionUri(databaseId, nameof(T)))
+                UriFactory.CreateDocumentCollectionUri(databaseId, typeof(T).Name))
                 .AsEnumerable<T>();
             return query.ToList<T>();
         }
@@ -54,25 +54,40 @@ namespace Services
         public async Task<T> GetDocumentAsync<T>()
         {
             var query = client.CreateDocumentQuery<T>(
-            UriFactory.CreateDocumentCollectionUri(databaseId, nameof(T)))
+            UriFactory.CreateDocumentCollectionUri(databaseId, typeof(T).Name))
             .AsEnumerable<T>();
             return query.FirstOrDefault<T>();
         }
 
-        
-        public async Task<T> GetServiceAsync<T>(string id) where T :IDocument
+
+        public async Task<T> GetServiceAsync<T>(string id) where T : IDocument
         {
-            var query = client.CreateDocumentQuery<T>(
-                UriFactory.CreateDocumentCollectionUri(databaseId, nameof(T)))
-                .Where(f => f.Id == id)
-                .AsEnumerable<T>();  
-            return query.FirstOrDefault<T>();
+            var docUri = UriFactory.CreateDocumentUri(databaseId, typeof(T).Name, id);
+            var doc = await client.ReadDocumentAsync<T>(docUri);
+            return doc.Document;
+
+            //    var uri = UriFactory.CreateDocumentCollectionUri(databaseId, typeof(T).Name);
+            //    var query = client.CreateDocumentQuery<T>(
+            //        uri,
+            //        new FeedOptions { EnableCrossPartitionQuery = true })
+            //        .Where(f => f.Id == id)
+            //        .AsEnumerable<T>();
+            //    List<T> list = new List<T>();
+            //   foreach (var i in query)
+            //    {
+            //        list.Add(i);
+            //    }
+            //    //            var result = query.FirstOrDefault<T>();
+            //    var list2 = list;
+            //    return list.FirstOrDefault<T>();
+            //
         }
 
         public async Task<IList<T>> GetDocumentsAsync<T>(string id) where T :IDocument
         {
             var query = client.CreateDocumentQuery<T>(
-                UriFactory.CreateDocumentCollectionUri(databaseId, nameof(T)))
+                UriFactory.CreateDocumentCollectionUri(databaseId, typeof(T).Name),
+                new FeedOptions { MaxItemCount = -1, EnableCrossPartitionQuery = true })
                 .Where(f => f.Id == id);           
             return query.ToList<T>();
         }
@@ -80,7 +95,7 @@ namespace Services
         public async Task<IList<T>> GetDocumentsAsync<T>(Func<IOrderedQueryable<T>, IQueryable<T>> queryFunction)
         {
             var queryBase = client.CreateDocumentQuery<T>(
-                UriFactory.CreateDocumentCollectionUri(databaseId, nameof(T)));
+                UriFactory.CreateDocumentCollectionUri(databaseId, typeof(T).Name));
             var query = queryFunction(queryBase);
             return query.ToList<T>();
         }

--- a/leaderboard/sentinel/helm/templates/pod.yaml
+++ b/leaderboard/sentinel/helm/templates/pod.yaml
@@ -13,7 +13,7 @@ spec:
     - name: SENTINEL_TEAM_ID
       value: {{ $.Values.teams.baseName }}{{ add1 $i }}
     - name: SENTINEL_SERVICE_ID
-      value: user
+      value: {{ $.Values.teams.baseName }}{{ add1 $i }}user
     - name: SENTINEL_ENDPOINT
       value: "http://akstraefik{{ $.Values.teams.baseName }}{{ add1 $i }}.{{ $.Values.teams.location }}.cloudapp.azure.com/api/healthcheck/user"
     - name: SENTINEL_PORT
@@ -38,7 +38,7 @@ spec:
     - name: SENTINEL_TEAM_ID
       value: {{ $.Values.teams.baseName }}{{ add1 $i }}
     - name: SENTINEL_SERVICE_ID
-      value: trip
+      value: {{ $.Values.teams.baseName }}{{ add1 $i }}trip
     - name: SENTINEL_ENDPOINT
       value: "http://akstraefik{{ $.Values.teams.baseName }}{{ add1 $i }}.{{ $.Values.teams.location }}.cloudapp.azure.com/api/healthcheck/trips"
     - name: SENTINEL_PORT
@@ -63,7 +63,7 @@ spec:
     - name: SENTINEL_TEAM_ID
       value: {{ $.Values.teams.baseName }}{{ add1 $i }}
     - name: SENTINEL_SERVICE_ID
-      value: poi
+      value: {{ $.Values.teams.baseName }}{{ add1 $i }}poi
     - name: SENTINEL_ENDPOINT
       value: "http://akstraefik{{ $.Values.teams.baseName }}{{ add1 $i }}.{{ $.Values.teams.location }}.cloudapp.azure.com/api/healthcheck/poi"
     - name: SENTINEL_PORT

--- a/leaderboard/web/src/environments/environment.prod.ts
+++ b/leaderboard/web/src/environments/environment.prod.ts
@@ -5,6 +5,6 @@
  */
 export const environment = {
   production: true,
-  backendUrl: "https://removeohprep20.azurewebsites.net/api/SampleFunc"
+  backendUrl: "https://removeohprep20.azurewebsites.net/api/GetTeamsStatus"
 };
 

--- a/leaderboard/web/src/environments/environment.ts
+++ b/leaderboard/web/src/environments/environment.ts
@@ -10,6 +10,6 @@
 
 export const environment = {
   production: false,
-  backendUrl: "https://removeohprep20.azurewebsites.net/api/SampleFunc"
+  backendUrl: "https://removeohprep20.azurewebsites.net/api/GetTeamsStatus"
 };
 


### PR DESCRIPTION
I fix two things. 

1. The endpoint URL of the failure report
2.  json file is not copied to the bin folder.
3. fix the issue that db is not match with sentinel 
   https://github.com/Azure-Samples/openhack-devops-proctor/issues/65

# NOTE 
currently, I investigating the root cause of 
https://github.com/Azure-Samples/openhack-devops-proctor/issues/66

However it is not done yet. Maybe Osvaldo can help. 

The problem is , When I query Service it returns no result (I confirm it has the data).  When I change it into the ReadDocumentAsync, current code returns ` PartitionKey value must be supplied for this operation.` Although we have PratitionKey.  However, times up. ( Now 0 am ...)

https://github.com/Azure-Samples/openhack-devops-proctor/blob/fix/leaderboardurl/leaderboard/api/SharedLibrary/DocumentService.cs#L63-L84

Other reference is 
https://stackoverflow.com/questions/36774126/how-do-you-pass-a-partitionkey-to-execute-a-storedprocedure
