### PR TITLE
Fix leaderboard web build:prod

### DIFF
--- a/leaderboard/web/Dockerfile
+++ b/leaderboard/web/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 ARG FUNCTION_NAME
 RUN grep -l 'devopsoh2subproc1fun' src/environments/*.ts | xargs sed -i.bak -e "s|devopsoh2subproc1fun|$FUNCTION_NAME|g"
 RUN npm install --silent
-RUN npm run build
+RUN npm run build:prod
 
 FROM nginx:1.13.12-alpine
 RUN rm -rf /usr/share/nginx/html

--- a/leaderboard/web/src/app/pages/dashboard/dashboard.component.ts
+++ b/leaderboard/web/src/app/pages/dashboard/dashboard.component.ts
@@ -20,7 +20,7 @@ interface TeamResponse {
 })
 export class DashboardComponent implements OnInit {
   private teams = [];
-  private viewTeams: {[k: string]: any}[]; // tslint:disable-line
+  public viewTeams: {[k: string]: any}[]; // tslint:disable-line
   private pollingData: any; // tslint:disable-line
 
   constructor(private http: HttpClient) {

--- a/leaderboard/web/src/app/pages/dashboard/solar/solar.component.ts
+++ b/leaderboard/web/src/app/pages/dashboard/solar/solar.component.ts
@@ -22,10 +22,10 @@ declare const echarts: any;
 })
 export class SolarComponent implements AfterViewInit, OnDestroy {
 
-  private value = 0;
-  private teamUptime = 0; // tslint:disable-line
-  private teamPoint = 0; // tslint:disable-line
-  private teamName = ""; // tslint:disable-line
+  public value = 0;
+  public teamUptime = 0; // tslint:disable-line
+  public teamPoint = 0; // tslint:disable-line
+  public teamName = ""; // tslint:disable-line
 
   @Input('uptime')
   set uptime(value: number) {


### PR DESCRIPTION
## Purpose
Fix `npm run build:prod`

When you do a `npm run build:prod` it errors out with:
ERROR in src\app\pages\dashboard\dashboard.component.html(1,15): : Property 'viewTeams' is private and only accessible
within class 'DashboardComponent'.
src\app\pages\dashboard\solar\solar.component.ts.SolarComponent.html(3,19): : Property 'teamName' is private and only accessible within class 'SolarComponent'.
src\app\pages\dashboard\solar\solar.component.ts.SolarComponent.html(8,26): : Property 'teamPoint' is private and only
accessible within class 'SolarComponent'.
src\app\pages\dashboard\solar\solar.component.ts.SolarComponent.html(9,47): : Property 'teamUptime' is private and only accessible within class 'SolarComponent'.

If you view the current web leaderboard it gives this on the initial startup: 
Angular is running in the development mode. Call enableProdMode() to enable the production mode.
The development build also is not optimized for performance and logs much more messages to the web console.