### PR TITLE
added verification of az cli version and --disable-rbac on aks cluster

### DIFF
--- a/provision-team/deploy_ingress_dns.sh
+++ b/provision-team/deploy_ingress_dns.sh
@@ -49,8 +49,6 @@ fi
 
 echo "Upgrading tiller (helm server) to match client version."
 
-
-
 kubectl create serviceaccount --namespace kube-system tiller
 
 kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller

--- a/provision-team/provision_aks.sh
+++ b/provision-team/provision_aks.sh
@@ -75,7 +75,7 @@ fi
 echo "Creating AKS Cluster..."
 (
     set -x
-    az aks create -g $resourceGroupName -n $clusterName -l $resourceGroupLocation --node-count 3 --generate-ssh-keys -k 1.9.6
+    az aks create -g $resourceGroupName -n $clusterName -l $resourceGroupLocation --node-count 3 --generate-ssh-keys -k 1.9.6 --disable-rbac
 )
 
 if [ $? == 0 ];

--- a/provision-team/provision_aks.sh
+++ b/provision-team/provision_aks.sh
@@ -69,13 +69,13 @@ fi
 if [ -f "~/.azure/aksServicePrincipal.json" ]; then
     NOW=$(date +"%Y%m%d-%H%M")
     mv ~/.azure/aksServicePrincipal.json ~/.azure/aksServicePrincipal_$NOW.json
-    echo "renamed existing local AKS Service Principal to ~/.azure/aksServicePrincipal_"$NOW".json" 
+    echo "renamed existing local AKS Service Principal to ~/.azure/aksServicePrincipal_"$NOW".json"
 fi
 
 echo "Creating AKS Cluster..."
 (
     set -x
-    az aks create -g $resourceGroupName -n $clusterName -l $resourceGroupLocation --node-count 3 --generate-ssh-keys -k 1.9.6 --disable-rbac
+    az aks create -g $resourceGroupName -n $clusterName -l $resourceGroupLocation --node-count 3 --generate-ssh-keys -k 1.9.6
 )
 
 if [ $? == 0 ];

--- a/provision-team/setup.sh
+++ b/provision-team/setup.sh
@@ -3,16 +3,16 @@
 # set -euo pipefail
 IFS=$'\n\t'
 
-usage() { echo "Usage: setup.sh -i <subscriptionId> -l <resourceGroupLocation> -n <teamName> -e <teamNumber> -c <az cli version>" 1>&2; exit 1; }
+usage() { echo "Usage: setup.sh -i <subscriptionId> -l <resourceGroupLocation> -n <teamName> -e <teamNumber>" 1>&2; exit 1; }
 
 declare subscriptionId=""
 declare resourceGroupLocation=""
 declare teamName=""
 declare teamNumber=""
-declare azcliVersion="2.0.41"
+declare azcliVerifiedVersion="2.0.38"
 
 # Initialize parameters specified from command line
-while getopts ":i:l:n:e:c:" arg; do
+while getopts ":i:l:n:e:" arg; do
     case "${arg}" in
         i)
             subscriptionId=${OPTARG}
@@ -25,9 +25,6 @@ while getopts ":i:l:n:e:c:" arg; do
         ;;
         e)
             teamNumber=${OPTARG}
-        ;;
-        c)
-            azcliVersion=${OPTARG}
         ;;
     esac
 done
@@ -55,10 +52,10 @@ if [ ! $? == 0 ]; then
     echo "The script need the az command line to be installed\n"
     echo "https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest"
     exit 1
-else 
+else
     currentCliVersion=$(echo "$(az --version)" | sed -ne 's/azure-cli (\(.*\))/\1/p' )
     if [ $currentCliVersion != $azcliVersion ]; then
-       echo "Error current az cli version $currentCliVersion does not match expected version $azcliVersion"
+       echo "Error current az cli version $currentCliVersion does not match expected version $azcliVerifiedVersion"
        exit 1
     fi
 fi

--- a/provision-team/setup.sh
+++ b/provision-team/setup.sh
@@ -3,15 +3,16 @@
 # set -euo pipefail
 IFS=$'\n\t'
 
-usage() { echo "Usage: setup.sh -i <subscriptionId> -l <resourceGroupLocation> -n <teamName> -e <teamNumber> " 1>&2; exit 1; }
+usage() { echo "Usage: setup.sh -i <subscriptionId> -l <resourceGroupLocation> -n <teamName> -e <teamNumber> -c <az cli version>" 1>&2; exit 1; }
 
 declare subscriptionId=""
 declare resourceGroupLocation=""
 declare teamName=""
 declare teamNumber=""
+declare azcliVersion="2.0.41"
 
 # Initialize parameters specified from command line
-while getopts ":i:l:n:e:" arg; do
+while getopts ":i:l:n:e:c:" arg; do
     case "${arg}" in
         i)
             subscriptionId=${OPTARG}
@@ -24,6 +25,9 @@ while getopts ":i:l:n:e:" arg; do
         ;;
         e)
             teamNumber=${OPTARG}
+        ;;
+        c)
+            azcliVersion=${OPTARG}
         ;;
     esac
 done
@@ -51,6 +55,12 @@ if [ ! $? == 0 ]; then
     echo "The script need the az command line to be installed\n"
     echo "https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest"
     exit 1
+else 
+    currentCliVersion=$(echo "$(az --version)" | sed -ne 's/azure-cli (\(.*\))/\1/p' )
+    if [ $currentCliVersion != $azcliVersion ]; then
+       echo "Error current az cli version $currentCliVersion does not match expected version $azcliVersion"
+       exit 1
+    fi
 fi
 
 #Prompt for parameters is some required parameters are missing

--- a/provision-vm/proctorVMSetup.sh
+++ b/provision-vm/proctorVMSetup.sh
@@ -78,7 +78,11 @@ sudo pwsh -command "& {Install-Module AzureRM.NetCore}"
 sudo pwsh -command "& {Import-Module AzureRM.Netcore}"
 sudo pwsh -command "& {Import-Module AzureRM.Profile.Netcore}"
 
+
 # Installing this at the end because for some reason it doesn't take effect when immediately after the AZ setup
 sudo apt-get install -y azure-cli=2.0.38-1~xenial
 
+echo azure-cli hold | sudo dpkg --set-selection
+
 sudo apt-get upgrade -y
+


### PR DESCRIPTION
This adds a verification on the az cli version to 2.0.41 by default since we upgraded the cli version in #94 and add --disable-rbac when provisioning the aks cluster.
 
@rguthriemsft PTAL
