### PR TITLE
Add User email/pass JWT authentication to Sentinel API

### DIFF
--- a/leaderboard/api/helm/templates/deployment.yaml
+++ b/leaderboard/api/helm/templates/deployment.yaml
@@ -48,6 +48,11 @@ spec:
               secretKeyRef:
                 name: sql
                 key: sql_dbname
+          - name: SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: jwt
+                key: secret_key
           - name: WEB_SERVER_BASE_URI
             value: 'http://0.0.0.0'
           - name: WEB_PORT

--- a/leaderboard/api/web/Auth/IJwtFactory.cs
+++ b/leaderboard/api/web/Auth/IJwtFactory.cs
@@ -1,0 +1,12 @@
+﻿
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace Sentinel.Auth
+{
+    public interface IJwtFactory
+    {
+        Task<string> GenerateEncodedToken(string userName, ClaimsIdentity identity);
+        ClaimsIdentity GenerateClaimsIdentity(string userName, string id);
+    }
+}

--- a/leaderboard/api/web/Auth/JwtFactory.cs
+++ b/leaderboard/api/web/Auth/JwtFactory.cs
@@ -1,0 +1,84 @@
+﻿
+
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Principal;
+using System.Threading.Tasks;
+using Sentinel.Models;
+using Microsoft.Extensions.Options;
+ 
+
+namespace Sentinel.Auth
+{
+    public class JwtFactory : IJwtFactory
+    {
+        private readonly JwtIssuerOptions _jwtOptions;
+
+        public JwtFactory(IOptions<JwtIssuerOptions> jwtOptions)
+        {
+            _jwtOptions = jwtOptions.Value;
+            ThrowIfInvalidOptions(_jwtOptions);
+        }
+
+        public async Task<string> GenerateEncodedToken(string userName, ClaimsIdentity identity)
+        {
+            var claims = new[]
+         {
+                 new Claim(JwtRegisteredClaimNames.Sub, userName),
+                 new Claim(JwtRegisteredClaimNames.Jti, await _jwtOptions.JtiGenerator()),
+                 new Claim(JwtRegisteredClaimNames.Iat, ToUnixEpochDate(_jwtOptions.IssuedAt).ToString(), ClaimValueTypes.Integer64),
+                 identity.FindFirst(Helpers.Constants.Strings.JwtClaimIdentifiers.Rol),
+                 identity.FindFirst(Helpers.Constants.Strings.JwtClaimIdentifiers.Id)
+             };
+
+            // Create the JWT security token and encode it.
+            var jwt = new JwtSecurityToken(
+                issuer: _jwtOptions.Issuer,
+                audience: _jwtOptions.Audience,
+                claims: claims,
+                notBefore: _jwtOptions.NotBefore,
+                expires: _jwtOptions.Expiration,
+                signingCredentials: _jwtOptions.SigningCredentials);
+
+            var encodedJwt = new JwtSecurityTokenHandler().WriteToken(jwt);
+
+            return encodedJwt;
+        }
+
+        public ClaimsIdentity GenerateClaimsIdentity(string userName, string id)
+        {
+            return new ClaimsIdentity(new GenericIdentity(userName, "Token"), new[]
+            {
+                new Claim(Helpers.Constants.Strings.JwtClaimIdentifiers.Id, id),
+                new Claim(Helpers.Constants.Strings.JwtClaimIdentifiers.Rol, Helpers.Constants.Strings.JwtClaims.ApiAccess)
+            });
+        }
+
+        /// <returns>Date converted to seconds since Unix epoch (Jan 1, 1970, midnight UTC).</returns>
+        private static long ToUnixEpochDate(DateTime date)
+          => (long)Math.Round((date.ToUniversalTime() -
+                               new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero))
+                              .TotalSeconds);
+
+        private static void ThrowIfInvalidOptions(JwtIssuerOptions options)
+        {
+            if (options == null) throw new ArgumentNullException(nameof(options));
+
+            if (options.ValidFor <= TimeSpan.Zero)
+            {
+                throw new ArgumentException("Must be a non-zero TimeSpan.", nameof(JwtIssuerOptions.ValidFor));
+            }
+
+            if (options.SigningCredentials == null)
+            {
+                throw new ArgumentNullException(nameof(JwtIssuerOptions.SigningCredentials));
+            }
+
+            if (options.JtiGenerator == null)
+            {
+                throw new ArgumentNullException(nameof(JwtIssuerOptions.JtiGenerator));
+            }
+        }
+    }
+}

--- a/leaderboard/api/web/Controllers/AccountsController.cs
+++ b/leaderboard/api/web/Controllers/AccountsController.cs
@@ -1,0 +1,50 @@
+﻿
+
+using System.Threading.Tasks;
+using Sentinel.Data;
+using Sentinel.Helpers;
+using Sentinel.Models;
+using Sentinel.Models.View;
+using AutoMapper;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+ 
+
+namespace Sentinel.Controllers
+{
+    [Route("api/[controller]")] 
+    public class AccountsController : Controller
+    {
+        private readonly AppUserContext _appDbContext;
+        private readonly UserManager<AppUser> _userManager;
+        private readonly IMapper _mapper;
+
+        public AccountsController(UserManager<AppUser> userManager, IMapper mapper, AppUserContext appDbContext)
+        {
+            _userManager = userManager;
+            _mapper = mapper;
+            _appDbContext = appDbContext;
+        }
+
+        // POST api/accounts
+        [HttpPost]
+        public async Task<IActionResult> Post([FromBody]RegistrationViewModel model)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            var userIdentity = _mapper.Map<AppUser>(model);
+
+            var result = await _userManager.CreateAsync(userIdentity, model.Password);
+
+            if (!result.Succeeded) return new BadRequestObjectResult(Errors.AddErrorsToModelState(result, ModelState));
+
+            await _appDbContext.AddAsync(new AppUser { });
+            await _appDbContext.SaveChangesAsync();
+
+            return new OkObjectResult("Account created");
+        }
+    }
+}

--- a/leaderboard/api/web/Controllers/AuthController.cs
+++ b/leaderboard/api/web/Controllers/AuthController.cs
@@ -1,0 +1,70 @@
+﻿
+ 
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Sentinel.Auth;
+using Sentinel.Helpers;
+using Sentinel.Models;
+using Sentinel.Models.View;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+ 
+
+namespace Sentinel.Controllers
+{
+    [Route("api/[controller]")]
+    public class AuthController : Controller
+    {
+        private readonly UserManager<AppUser> _userManager;
+        private readonly IJwtFactory _jwtFactory;
+        private readonly JwtIssuerOptions _jwtOptions;
+
+        public AuthController(UserManager<AppUser> userManager, IJwtFactory jwtFactory, IOptions<JwtIssuerOptions> jwtOptions)
+        {
+            _userManager = userManager;
+            _jwtFactory = jwtFactory;
+            _jwtOptions = jwtOptions.Value;
+        }
+
+        // POST api/auth/login
+        [HttpPost("login")]
+        public async Task<IActionResult> Post([FromBody]CredentialsViewModel credentials)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            var identity = await GetClaimsIdentity(credentials.UserName, credentials.Password);
+            if (identity == null)
+            {
+                return BadRequest(Errors.AddErrorToModelState("login_failure", "Invalid username or password.", ModelState));
+            }
+
+          var jwt = await Tokens.GenerateJwt(identity, _jwtFactory, credentials.UserName, _jwtOptions, new JsonSerializerSettings { Formatting = Formatting.Indented });
+          return new OkObjectResult(jwt);
+        }
+
+        private async Task<ClaimsIdentity> GetClaimsIdentity(string userName, string password)
+        {
+            if (string.IsNullOrEmpty(userName) || string.IsNullOrEmpty(password))
+                return await Task.FromResult<ClaimsIdentity>(null);
+
+            // get the user to verifty
+            var userToVerify = await _userManager.FindByNameAsync(userName);
+
+            if (userToVerify == null) return await Task.FromResult<ClaimsIdentity>(null);
+
+            // check the credentials
+            if (await _userManager.CheckPasswordAsync(userToVerify, password))
+            {
+                return await Task.FromResult(_jwtFactory.GenerateClaimsIdentity(userName, userToVerify.Id));
+            }
+
+            // Credentials are invalid, or account doesn't exist
+            return await Task.FromResult<ClaimsIdentity>(null);
+        }
+    }
+}

--- a/leaderboard/api/web/Data/AppUserContext.cs
+++ b/leaderboard/api/web/Data/AppUserContext.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Sentinel.Models;
+
+namespace Sentinel.Data
+{
+    public class AppUserContext : IdentityDbContext<AppUser>
+    {
+        public AppUserContext(DbContextOptions<AppUserContext> options) : base(options)
+        {
+
+        }
+
+        public DbSet<AppUser> AppUser { get; set; }
+
+    }
+}

--- a/leaderboard/api/web/Helpers/Constants.cs
+++ b/leaderboard/api/web/Helpers/Constants.cs
@@ -1,0 +1,19 @@
+﻿
+namespace Sentinel.Helpers
+{
+    public static class Constants
+    {
+        public static class Strings
+        {
+            public static class JwtClaimIdentifiers
+            {
+                public const string Rol = "rol", Id = "id";
+            }
+
+            public static class JwtClaims
+            {
+                public const string ApiAccess = "api_access";
+            }
+        }
+    }
+}

--- a/leaderboard/api/web/Helpers/Errors.cs
+++ b/leaderboard/api/web/Helpers/Errors.cs
@@ -1,0 +1,27 @@
+﻿
+
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace Sentinel.Helpers
+    { 
+        public static class Errors
+        {
+            public static ModelStateDictionary AddErrorsToModelState(IdentityResult identityResult, ModelStateDictionary modelState)
+            {
+                foreach (var e in identityResult.Errors)
+                {
+                    modelState.TryAddModelError(e.Code, e.Description);
+                }
+
+                return modelState;
+            }
+
+            public static ModelStateDictionary AddErrorToModelState(string code, string description, ModelStateDictionary modelState)
+            {
+                modelState.TryAddModelError(code, description);
+                return modelState;
+            }
+        }
+    }
+

--- a/leaderboard/api/web/Helpers/ResponseExtensions.cs
+++ b/leaderboard/api/web/Helpers/ResponseExtensions.cs
@@ -1,0 +1,15 @@
+
+using Microsoft.AspNetCore.Http;
+
+namespace Sentinel.Helpers
+{
+    public static class ResponseExtensions
+    {
+        public static void AddApplicationError(this HttpResponse response, string message)
+        {
+            response.Headers.Add("Application-Error", message);
+            // CORS
+            response.Headers.Add("access-control-expose-headers", "Application-Error");
+        }
+    }
+}

--- a/leaderboard/api/web/Helpers/Tokens.cs
+++ b/leaderboard/api/web/Helpers/Tokens.cs
@@ -1,0 +1,26 @@
+
+
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Sentinel.Auth;
+using Sentinel.Models;
+using Newtonsoft.Json;
+
+namespace Sentinel.Helpers
+{
+    public class Tokens
+    {
+      public static async Task<string> GenerateJwt(ClaimsIdentity identity, IJwtFactory jwtFactory,string userName, JwtIssuerOptions jwtOptions, JsonSerializerSettings serializerSettings)
+      {
+        var response = new
+        {
+          id = identity.Claims.Single(c => c.Type == "id").Value,
+          auth_token = await jwtFactory.GenerateEncodedToken(userName, identity),
+          expires_in = (int)jwtOptions.ValidFor.TotalSeconds
+        };
+
+        return JsonConvert.SerializeObject(response, serializerSettings);
+      }
+    }
+}

--- a/leaderboard/api/web/Models/AppUser.cs
+++ b/leaderboard/api/web/Models/AppUser.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.AspNetCore.Identity;
+
+namespace Sentinel.Models
+{
+    public class AppUser : IdentityUser
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+
+    }
+}

--- a/leaderboard/api/web/Models/JwtIssuerOptions.cs
+++ b/leaderboard/api/web/Models/JwtIssuerOptions.cs
@@ -1,0 +1,59 @@
+
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Sentinel.Models
+{
+    public class JwtIssuerOptions
+    {
+        /// <summary>
+        /// 4.1.1.  "iss" (Issuer) Claim - The "iss" (issuer) claim identifies the principal that issued the JWT.
+        /// </summary>
+        public string Issuer { get; set; }
+
+        /// <summary>
+        /// 4.1.2.  "sub" (Subject) Claim - The "sub" (subject) claim identifies the principal that is the subject of the JWT.
+        /// </summary>
+        public string Subject { get; set; }
+
+        /// <summary>
+        /// 4.1.3.  "aud" (Audience) Claim - The "aud" (audience) claim identifies the recipients that the JWT is intended for.
+        /// </summary>
+        public string Audience { get; set; }
+
+        /// <summary>
+        /// 4.1.4.  "exp" (Expiration Time) Claim - The "exp" (expiration time) claim identifies the expiration time on or after which the JWT MUST NOT be accepted for processing.
+        /// </summary>
+        public DateTime Expiration => IssuedAt.Add(ValidFor);
+
+        /// <summary>
+        /// 4.1.5.  "nbf" (Not Before) Claim - The "nbf" (not before) claim identifies the time before which the JWT MUST NOT be accepted for processing.
+        /// </summary>
+        public DateTime NotBefore => DateTime.UtcNow;
+
+        /// <summary>
+        /// 4.1.6.  "iat" (Issued At) Claim - The "iat" (issued at) claim identifies the time at which the JWT was issued.
+        /// </summary>
+        public DateTime IssuedAt => DateTime.UtcNow;
+
+        /// <summary>
+        /// Set the timespan the token will be valid for (default is 120 min)
+        /// </summary>
+        public TimeSpan ValidFor { get; set; } = TimeSpan.FromMinutes(120);
+
+
+
+        /// <summary>
+        /// "jti" (JWT ID) Claim (default ID is a GUID)
+        /// </summary>
+        public Func<Task<string>> JtiGenerator =>
+          () => Task.FromResult(Guid.NewGuid().ToString());
+
+        /// <summary>
+        /// The signing key to use when generating tokens.
+        /// </summary>
+        public SigningCredentials SigningCredentials { get; set; }
+    }
+}

--- a/leaderboard/api/web/Models/View/CredentialsViewModel.cs
+++ b/leaderboard/api/web/Models/View/CredentialsViewModel.cs
@@ -1,0 +1,13 @@
+﻿
+using Sentinel.Models.View.Validations;
+using FluentValidation.Attributes;
+
+namespace Sentinel.Models.View
+{
+    [Validator(typeof(CredentialsViewModelValidator))]
+    public class CredentialsViewModel
+    {
+        public string UserName { get; set; }
+        public string Password { get; set; }
+    }
+}

--- a/leaderboard/api/web/Models/View/Mappings/ViewModelToEntityMappingProfile.cs
+++ b/leaderboard/api/web/Models/View/Mappings/ViewModelToEntityMappingProfile.cs
@@ -1,0 +1,16 @@
+﻿
+using Sentinel.Models.View;
+using Sentinel.Models;
+using AutoMapper;
+ 
+
+namespace AngularASPNETCore2WebApiAuth.ViewModels.Mappings
+{
+    public class ViewModelToEntityMappingProfile : Profile
+    {
+        public ViewModelToEntityMappingProfile()
+        {
+            CreateMap<RegistrationViewModel, AppUser>().ForMember(au => au.UserName, map => map.MapFrom(vm => vm.Email));
+        }
+    }
+}

--- a/leaderboard/api/web/Models/View/RegistrationViewModel.cs
+++ b/leaderboard/api/web/Models/View/RegistrationViewModel.cs
@@ -1,0 +1,13 @@
+﻿
+
+namespace Sentinel.Models.View
+{
+    public class RegistrationViewModel
+    {
+        public string Email { get; set; }
+        public string Password { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string Location { get; set; }
+    }
+}

--- a/leaderboard/api/web/Models/View/Validations/CredentialsViewModelValidator.cs
+++ b/leaderboard/api/web/Models/View/Validations/CredentialsViewModelValidator.cs
@@ -1,0 +1,16 @@
+﻿
+using FluentValidation;
+ 
+
+namespace Sentinel.Models.View.Validations
+{
+    public class CredentialsViewModelValidator : AbstractValidator<CredentialsViewModel>
+    {
+        public CredentialsViewModelValidator()
+        {
+            RuleFor(vm => vm.UserName).NotEmpty().WithMessage("Username cannot be empty");
+            RuleFor(vm => vm.Password).NotEmpty().WithMessage("Password cannot be empty");
+            RuleFor(vm => vm.Password).Length(6, 12).WithMessage("Password must be between 6 and 12 characters");
+        }
+    }
+}

--- a/leaderboard/api/web/Models/View/Validations/RegistrationViewModelValidator.cs
+++ b/leaderboard/api/web/Models/View/Validations/RegistrationViewModelValidator.cs
@@ -1,0 +1,18 @@
+﻿
+using FluentValidation;
+ 
+
+namespace Sentinel.Models.View.Validations
+{
+    public class RegistrationViewModelValidator : AbstractValidator<RegistrationViewModel>
+    {
+        public RegistrationViewModelValidator()
+        {
+            RuleFor(vm => vm.Email).NotEmpty().WithMessage("Email cannot be empty");
+            RuleFor(vm => vm.Password).NotEmpty().WithMessage("Password cannot be empty");
+            RuleFor(vm => vm.FirstName).NotEmpty().WithMessage("FirstName cannot be empty");
+            RuleFor(vm => vm.LastName).NotEmpty().WithMessage("LastName cannot be empty");
+            RuleFor(vm => vm.Location).NotEmpty().WithMessage("Location cannot be empty");
+        }
+    }
+}

--- a/leaderboard/api/web/Sentinel.csproj
+++ b/leaderboard/api/web/Sentinel.csproj
@@ -11,10 +11,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="3.2.0" />
+    <PackageReference Include="fluentvalidation.aspnetcore" Version="7.3.3" />
   </ItemGroup>
   <ItemGroup>
     <Content Remove="Properties\launchSettings.json" />

--- a/leaderboard/api/web/Startup.cs
+++ b/leaderboard/api/web/Startup.cs
@@ -26,9 +26,6 @@ namespace Sentinel
     public class Startup
     {
 
-        private const string SecretKey = "iNivDmHLpUA223sqsfhqGbMRdRj1PVkH"; // todo: get this from somewhere secure
-        private readonly SymmetricSecurityKey _signingKey = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(SecretKey));
-
         public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
@@ -57,6 +54,8 @@ namespace Sentinel
 
             services.AddDbContext<LeaderboardContext>(options =>
                 options.UseSqlServer(connectionString));
+
+            var _signingKey = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(SentinelConfiguration.GetSecretKey(Configuration)));
 
             services.AddSingleton<IJwtFactory, JwtFactory>();
             // jwt wire up

--- a/leaderboard/api/web/Startup.cs
+++ b/leaderboard/api/web/Startup.cs
@@ -2,24 +2,42 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
 using System.Reflection;
+using AutoMapper;
+using FluentValidation.AspNetCore;
 using Newtonsoft.Json;
-using Sentinel.Utility;
+using Sentinel.Auth;
 using Sentinel.Data;
+using Sentinel.Helpers;
+using Sentinel.Models;
+using Sentinel.Utility;
+
+// using System.Net;
+// using AngularASPNETCore2WebApiAuth.Extensions;
+// using Microsoft.AspNetCore.Diagnostics;
+// using Microsoft.AspNetCore.Http;
 
 namespace Sentinel
 {
     public class Startup
     {
+
+        private const string SecretKey = "iNivDmHLpUA223sqsfhqGbMRdRj1PVkH"; // todo: get this from somewhere secure
+        private readonly SymmetricSecurityKey _signingKey = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(SecretKey));
+
         public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
@@ -30,6 +48,7 @@ namespace Sentinel
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+
             services.AddMvc()
                     .SetCompatibilityVersion(CompatibilityVersion.Version_2_1)
                     .AddJsonOptions(Options =>
@@ -39,11 +58,77 @@ namespace Sentinel
 
             var connectionString = SentinelConfiguration.GetConnectionString(this.Configuration);
 
+            services.AddDbContext<AppUserContext>(options =>
+                options.UseSqlServer(connectionString));
+
             services.AddDbContext<LogMessageContext>(options =>
                 options.UseSqlServer(connectionString));
 
             services.AddDbContext<LeaderboardContext>(options =>
                 options.UseSqlServer(connectionString));
+
+            // jwt wire up
+            // Get options from app settings
+            var jwtAppSettingOptions = Configuration.GetSection(nameof(JwtIssuerOptions));
+
+            // Configure JwtIssuerOptions
+            services.Configure<JwtIssuerOptions>(options =>
+            {
+                options.Issuer = jwtAppSettingOptions[nameof(JwtIssuerOptions.Issuer)];
+                options.Audience = jwtAppSettingOptions[nameof(JwtIssuerOptions.Audience)];
+                options.SigningCredentials = new SigningCredentials(_signingKey, SecurityAlgorithms.HmacSha256);
+            });
+
+            var tokenValidationParameters = new TokenValidationParameters
+            {
+                ValidateIssuer = true,
+                ValidIssuer = jwtAppSettingOptions[nameof(JwtIssuerOptions.Issuer)],
+
+                ValidateAudience = true,
+                ValidAudience = jwtAppSettingOptions[nameof(JwtIssuerOptions.Audience)],
+
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKey = _signingKey,
+
+                RequireExpirationTime = false,
+                ValidateLifetime = true,
+                ClockSkew = TimeSpan.Zero
+            };
+
+            services.AddAuthentication(options =>
+            {
+                options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+                options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+
+            }).AddJwtBearer(configureOptions =>
+            {
+                configureOptions.ClaimsIssuer = jwtAppSettingOptions[nameof(JwtIssuerOptions.Issuer)];
+                configureOptions.TokenValidationParameters = tokenValidationParameters;
+                configureOptions.SaveToken = true;
+            });
+
+            // api user claim policy
+            services.AddAuthorization(options =>
+            {
+                options.AddPolicy("ApiUser", policy => policy.RequireClaim(Constants.Strings.JwtClaimIdentifiers.Rol, Constants.Strings.JwtClaims.ApiAccess));
+            });
+
+            // add identity
+            var builder = services.AddIdentityCore<AppUser>(o =>
+            {
+                // configure identity options
+                o.Password.RequireDigit = false;
+                o.Password.RequireLowercase = false;
+                o.Password.RequireUppercase = false;
+                o.Password.RequireNonAlphanumeric = false;
+                o.Password.RequiredLength = 6;
+            });
+            builder = new IdentityBuilder(builder.UserType, typeof(IdentityRole), builder.Services);
+            builder.AddEntityFrameworkStores<AppUserContext>().AddDefaultTokenProviders();
+
+            services.AddAutoMapper();
+            services.AddMvc().AddFluentValidation(fv => fv.RegisterValidatorsFromAssemblyContaining<Startup>());
+
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/leaderboard/api/web/Utility/Configuration.cs
+++ b/leaderboard/api/web/Utility/Configuration.cs
@@ -21,6 +21,13 @@ namespace Sentinel.Utility
             return connectionString;
         }
 
+        public static string GetSecretKey(IConfiguration configuration)
+        {
+            var SECRET_KEY = configuration.GetValue(typeof(string),"SECRET_KEY","changeMe2SecureValue");
+
+            return SECRET_KEY.ToString();
+
+        }
         public static string GetUri(IConfiguration configuration)
         {
             var WEB_PORT = configuration.GetValue(typeof(string),"WEB_PORT","8080");

--- a/provision-proctor/build_deploy_sentinel_api.sh
+++ b/provision-proctor/build_deploy_sentinel_api.sh
@@ -101,6 +101,10 @@ echo -e "\nSuccessfully pushed image: "$TAG
 
 popd
 
+echo -e "\nAdding JWT Signing Key Secret\n\n"
+randomString=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-32};echo;)
+kubectl create secret generic jwt --type=string --from-literal=secret_key=$randomString
+
 installPath="../leaderboard/api/helm"
 echo -e "\nhelm install from: " $installPath "\n\n"
 


### PR DESCRIPTION
## Purpose
- Adds the ability for new users to be added with email and password and have them login and get back a JWT token

**TO DO (DO NOT MERGE YET)**

- [ ] Add SQL commands to provision tables during environment creation
- [ ] Test End-to-End deployment of entire proctor environment