### PR TITLE
Fix leaderboard api url

### DIFF
--- a/leaderboard/web/mockserver/index.js
+++ b/leaderboard/web/mockserver/index.js
@@ -27,4 +27,4 @@ let homepage = "<a href=http://localhost:3000/api/leaderboard/teams/>/api/leader
 
 app.get('/', (req, res) => res.send(homepage))
 app.get('/api/leaderboard/teams/', (req, res) => res.send(JSON.stringify(teams)))
-app.listen(3000, () => console.log('Example app listening on port 3000!'))
+app.listen(8080, () => console.log('Example app listening on port 8080!'))

--- a/leaderboard/web/src/environments/environment.prod.ts
+++ b/leaderboard/web/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  backendUrl: 'http://devopsoh2subproc1fun/api/leaderboard/teams', // process.env.API_URL || ''
+  backendUrl: 'http://devopsoh2subproc1fun/api/leaderboard/',
 };


### PR DESCRIPTION
## Purpose
- fixes the production build of the leaderboard website to go to `/teams` versus `/teamsteams`
- updates the mockserver to use the same port as the development environment config