### PR TITLE
Update monitoring deployment to automate sentinel

### DIFF
--- a/provision-proctor/deploy_sentinel.sh
+++ b/provision-proctor/deploy_sentinel.sh
@@ -44,11 +44,16 @@ if [[ -z "$csvFile" ]]; then
     [[ "${csvFile:?}" ]]
 fi
 
+if [ ! -f $csvFile ]; then
+    echo "File $csvFile not found"
+    exit 1
+fi
+
 chartPath="../leaderboard/sentinel/helm"
 echo -e "\nhelm install ... from: " $chartPath
 
 # Obtain the kvstore files from the teams 
-UNIQUECRED=$(awk -F, '!seen[$3]++' credentials.csv)
+UNIQUECRED=$(awk -F, '!seen[$3]++' $csvFile)
 
 for cred in $UNIQUECRED
 do 

--- a/provision-proctor/deploy_sentinel.sh
+++ b/provision-proctor/deploy_sentinel.sh
@@ -6,7 +6,7 @@ IFS=$'\n\t'
 # If no team is specified it will read the entries in the kvstore and deploy sentinel for the successfull ones
 # If a team is specified it will deploy sentinel only for this one
 
-usage() { echo "Usage: deploy_sentinel.sh -p <proctorEnvironmentName> -n <teamName - Optional>" 1>&2; exit 1; }
+usage() { echo "Usage: deploy_sentinel.sh -p <proctorEnvironmentName> -n <teamName - Optional> -f credentials.csv" 1>&2; exit 1; }
 
 declare -a keys
 declare registryName=""
@@ -14,10 +14,14 @@ declare apiUrl=""
 declare teamList=""
 declare teamName=""
 declare teamEndPoint=""
+declare csvFile=""
 
 # Initialize parameters specified from command line
 while getopts ":p:n:" arg; do
     case "${arg}" in
+        f)
+            csvFile=${OPTARG}
+        ;;
         p)  
             proctorEnvName=${OPTARG}
         ;;
@@ -34,8 +38,38 @@ if [[ -z "$proctorEnvName" ]]; then
     [[ "${proctorEnvName:?}" ]]
 fi
 
+if [[ -z "$csvFile" ]]; then
+    echo "Speficy the location of file containing the teams' Azure credentials"
+    read csvFile
+    [[ "${csvFile:?}" ]]
+fi
+
 chartPath="../leaderboard/sentinel/helm"
 echo -e "\nhelm install ... from: " $chartPath
+
+# Obtain the kvstore files from the teams 
+UNIQUECRED=$(awk -F, '!seen[$3]++' credentials.csv)
+
+for cred in $UNIQUECRED
+do 
+    # echo "Line: $cred"
+    subid=$(echo $cred | awk -F ", " '{ print $3 }')
+    username=$(echo $cred | awk -F ", " '{ print $5 }')
+    password=$(echo $cred | awk -F ", " '{ print $6 }')
+    #echo "Subscription: $subid"
+    #echo "username: $username"
+    #echo "Password: $password"
+    GUID=$(echo $subid | sed -E -e 's/.{8}-.{4}-.{4}-.{4}-.{12}/guid/')
+    if [[ $GUID == "guid" ]]; then
+        az login --username=$username --password=$password > /dev/null
+        ipaddress=$(az vm list-ip-addresses --resource-group=ProctorVMRG --name=proctorVM --query "[].virtualMachine.network.publicIpAddresses[].ipAddress" -otsv)
+        if [[ $ipaddress =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            teamAAD=$(echo "$username"  | sed -e 's/.*?*@\(.*\)ops.onmicrosoft.com/\1/')
+            curl -o /home/azureuser/team_env/kvstore/$teamAAD http://${ipaddress}:2018/ohteamvalues 
+            echo "$teamAAD is at $ipaddress"
+        fi
+    fi
+done
 
 # Getting the registry name and the apiUrl from kvstore
 registryName="$(kvstore get $proctorEnvName ACR).azurecr.io"

--- a/provision-proctor/monitoringVMSetup.sh
+++ b/provision-proctor/monitoringVMSetup.sh
@@ -8,7 +8,7 @@ AZUREUSERNAME=$1
 AZUREPASSWORD=$2
 SUBID=$3
 LOCATION=$4
-GITBRANCH=$(git branch | grep \* | cut -d ' ' -f2)
+#GITBRANCH=$(git branch | grep \* | cut -d ' ' -f2)
 
 echo "############### Adding package respositories ###############"
 # Get the Microsoft signing key 
@@ -48,17 +48,17 @@ echo "############### Installing Packages ###############"
 #  - powershell 
 #  - docker-ce
 
-sudo apt-get update 
-sudo apt-get install -y apt-transport-https
-sudo apt-get install -y jq git zip azure-cli=2.0.43-1~xenial
-sudo ACCEPT_EULA=Y apt-get install -y mssql-tools unixodbc-dev
-sudo apt-get install -y docker-ce
+sudo DEBIAN_FRONTEND=noninteractive apt-get update 
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y jq git zip azure-cli=2.0.43-1~xenial
+sudo DEBIAN_FRONTEND=noninteractive ACCEPT_EULA=Y apt-get install -y mssql-tools unixodbc-dev
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce
 
 touch /home/azureuser/.bashrc
 echo 'export PATH=$PATH:/opt/mssql-tools/bin' >> /home/azureuser/.bashrc
 
 echo "############### Pulling Openhack-tools from Github ###############"
-sudo git clone -b master https://github.com/Azure-Samples/openhack-devops-proctor.git /home/azureuser/openhack-devops-proctor
+sudo git clone https://github.com/Azure-Samples/openhack-devops-proctor.git /home/azureuser/openhack-devops-proctor
 sudo chown azureuser:azureuser -R /home/azureuser/openhack-devops-proctor/.
 
 echo "############### Install kvstore ###############"
@@ -68,7 +68,7 @@ echo 'export KVSTORE_DIR=/home/azureuser/team_env/kvstore' >> /home/azureuser/.b
 #pick up changes to bash profile
 #source /home/azureuser/.bashrc
 
-echo azure-cli hold | sudo dpkg --set-selection
+echo azure-cli hold | sudo dpkg --set-selections
 
 #Add user to docker usergroup
 sudo usermod -aG docker azureuser
@@ -78,7 +78,7 @@ sudo apt-get upgrade -y
 export PATH=$PATH:/opt/mssql-tools/bin
 export KVSTORE_DIR=/home/azureuser/team_env/kvstore
 
-cd /home/azureuser/openhack-devops-proctor/provision-team
+cd /home/azureuser/openhack-devops-proctor/provision-proctor
 
 echo "############### Azure credentials ###############"
 echo "UserName: $AZUREUSERNAME"

--- a/provision-proctor/monitoringVMSetup.sh
+++ b/provision-proctor/monitoringVMSetup.sh
@@ -90,6 +90,6 @@ echo "Location: $LOCATION"
 az login --username=$AZUREUSERNAME --password=$AZUREPASSWORD
 
 # Launching the team provisioning in background
-sudo PATH=$PATH:/opt/mssql-tools/bin KVSTORE_DIR=/home/azureuser/team_env/kvstore nohup ./setup.sh -i $SUBID -l $LOCATION -u "$AZUREUSERNAME" -p "$AZUREPASSWORD">monitoringeploy.out &
+sudo PATH=$PATH:/opt/mssql-tools/bin KVSTORE_DIR=/home/azureuser/team_env/kvstore nohup ./setup.sh -i $SUBID -l $LOCATION -u '$AZUREUSERNAME' -p '$AZUREPASSWORD'>monitoringeploy.out &
 
 echo "############### End of custom script ###############"

--- a/provision-proctor/monitoringVMSetup.sh
+++ b/provision-proctor/monitoringVMSetup.sh
@@ -90,6 +90,6 @@ echo "Location: $LOCATION"
 az login --username=$AZUREUSERNAME --password=$AZUREPASSWORD
 
 # Launching the team provisioning in background
-sudo PATH=$PATH:/opt/mssql-tools/bin KVSTORE_DIR=/home/azureuser/team_env/kvstore nohup ./setup.sh -i $SUBID -l $LOCATION -u '$AZUREUSERNAME' -p '$AZUREPASSWORD'>monitoringeploy.out &
+sudo PATH=$PATH:/opt/mssql-tools/bin KVSTORE_DIR=/home/azureuser/team_env/kvstore nohup ./setup.sh -i $SUBID -l $LOCATION -u "$AZUREUSERNAME" -p "$AZUREPASSWORD">monitoringeploy.out &
 
 echo "############### End of custom script ###############"

--- a/provision-proctor/monitoringVMSetup.sh
+++ b/provision-proctor/monitoringVMSetup.sh
@@ -90,6 +90,6 @@ echo "Location: $LOCATION"
 az login --username=$AZUREUSERNAME --password=$AZUREPASSWORD
 
 # Launching the team provisioning in background
-sudo PATH=$PATH:/opt/mssql-tools/bin KVSTORE_DIR=/home/azureuser/team_env/kvstore nohup ./setup.sh -i $SUBID -l $LOCATION -u "$AZUREUSERNAME" -p "$AZUREPASSWORD">monitoringeploy.out &
+sudo PATH=$PATH:/opt/mssql-tools/bin KVSTORE_DIR=/home/azureuser/team_env/kvstore nohup ./setup.sh -i $SUBID -l $LOCATION -u "$AZUREUSERNAME" -p "$AZUREPASSWORD">monitoringdeploy.out &
 
 echo "############### End of custom script ###############"

--- a/provision-proctor/setup.sh
+++ b/provision-proctor/setup.sh
@@ -209,8 +209,9 @@ bash ./build_deploy_sentinel_api.sh -b Release -r $resourceGroupProctor -t 'sent
 echo "7-Build sentinel and push to ACR (bash ./build_sentinel.sh -r $resourceGroupProctor -g $registryName -l $resourceGroupLocation -a $apiUrl)"
 bash ./build_sentinel.sh -r $resourceGroupProctor -g $registryName -l $resourceGroupLocation -a $apiUrl
 
-echo "8-Deploy sentinel to AKS"
-bash ./deploy_sentinel.sh -p ${proctorName}${proctorNumber}
+####### Commenting sentinel deployment to manual step for the moment since it needs the teams credentials files
+# echo "8-Deploy sentinel to AKS"
+# bash ./deploy_sentinel.sh -p ${proctorName}${proctorNumber} -f ${credentials.csv}
 
 echo "9-Build and deploy leaderboard website to AKS  (bash ./build_deploy_web.sh -m ${proctorName}${proctorNumber} -d $dnsURL)"
 bash ./build_deploy_web.sh -m ${proctorName}${proctorNumber} -d $dnsURL

--- a/provision-team/cleanup_environment.sh
+++ b/provision-team/cleanup_environment.sh
@@ -25,14 +25,11 @@ if [[ ! -d "/home/azureuser/www" ]]; then
     mkdir -p /home/azureuser/www
 fi 
 
-sudo zip /home/azureuser/www/teamfiles.zip /root/.kube/config /root/.azure/aksServicePrincipal.json /home/azureuser/team_env/kvstore/${teamName}
-sudo cp /home/azureuser/team_env/kvstore/${teamName} /home/azureuser/www/ohteamvalues
-sudo cp /home/azureuser/openhack-devops-proctor/provision-team/nginx/index.html /home/azureuser/www/index.html
-
 # 1- Rename /home/azureuser/.azure/aksServicePrincipal.json to /home/azureuser/.azure/aksServicePrincipal-team-number.json
 if [ -f /home/root/.azure/aksServicePrincipal.json ]; then
     aksSPlocation="/home/azureuser/team_env/$teamName/aksServicePrincipal-$teamName.json"
     cp /home/azureuser/.azure/aksServicePrincipal.json $aksSPlocation
+    sudo cp /root/.azure/aksServicePrincipal.json /home/azureuser/www/aksServicePrincipal.json
     kvstore set $teamName aksSPlocation $aksSPlocation
     echo "The aksServicePrincipal.json file has been moved to $aksSPlocation"
 fi
@@ -41,7 +38,11 @@ fi
 if [ -f /home/root/.kube/config ]; then
     kubeconfiglocation="/home/azureuser/team_env/$teamName/kubeconfig-$teamName"
     cp /home/azureuser/.kube/config $kubeconfiglocation
+    sudo cp /root/.kube/config /home/azureuser/www/kubeconfig
     kvstore set $teamName kubeconfig $kubeconfiglocation
     echo "Copied the kubeconfig file to $kubeconfiglocation"
 fi
 
+sudo zip /home/azureuser/www/teamfiles.zip /home/azureuser/www/kubeconfig /home/azureuser/www/aksServicePrincipal.json /home/azureuser/team_env/kvstore/${teamName}
+sudo cp /home/azureuser/team_env/kvstore/${teamName} /home/azureuser/www/ohteamvalues
+sudo cp /home/azureuser/openhack-devops-proctor/provision-team/nginx/index.html /home/azureuser/www/index.html


### PR DESCRIPTION
## Purpose
Added routine to loop through the user credentials and get their kvstore file then deploy sentinel to point at their IP.

Sentinel has been commented in the setup script since the new deployment script does an exit 1 in the case the file is not present.

## Does this introduce a breaking change?
```
[X] Yes
[ ] No
```

