### PR TITLE
Add password to Jenkins login

### DIFF
--- a/provision-team/configure_jenkins.sh
+++ b/provision-team/configure_jenkins.sh
@@ -28,4 +28,4 @@ sudo mv linux-amd64/helm /usr/local/bin/helm
 usermod -aG docker azureuser
 
 # Run Jenkins
-sudo docker run -d -v jenkins_home:/var/jenkins_home -p 8080:8080 -p 50000:50000 -e JENKINS_PASS:$JENKINSPASSWORD oguzpastirmaci/openhack-jenkins-docker:envtest
+sudo docker run -d -v jenkins_home:/var/jenkins_home -p 8080:8080 -p 50000:50000 -e "JENKINS_PASS=$JENKINSPASSWORD" oguzpastirmaci/openhack-jenkins-docker

--- a/provision-team/configure_jenkins.sh
+++ b/provision-team/configure_jenkins.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+JENKINSPASSWORD=$1
+
 # Docker
 sudo apt-get install apt-transport-https ca-certificates curl software-properties-common -y
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
@@ -26,4 +28,4 @@ sudo mv linux-amd64/helm /usr/local/bin/helm
 usermod -aG docker azureuser
 
 # Run Jenkins
-sudo docker run -d -v jenkins_home:/var/jenkins_home -p 8080:8080 -p 50000:50000 oguzpastirmaci/openhack-jenkins-docker
+sudo docker run -d -v jenkins_home:/var/jenkins_home -p 8080:8080 -p 50000:50000 -e JENKINS_PASS:$JENKINSPASSWORD oguzpastirmaci/openhack-jenkins-docker:envtest


### PR DESCRIPTION
Sets the Jenkins VM password as the Jenkins password instead of having an open login to Jenkins.