### PR TITLE
add servicehealth ingress route

### DIFF
--- a/leaderboard/api/helm/values.yaml
+++ b/leaderboard/api/helm/values.yaml
@@ -30,6 +30,9 @@ ingress:
       - path: /api/leaderboard/challenges
         serviceName: sentinel-api-svc
         servicePort: 80
+      - path: /api/leaderboard/servicehealth
+        serviceName: sentinel-api-svc
+        servicePort: 80
       - path: /api/healthcheck/sentinel
         serviceName: sentinel-api-svc
         servicePort: 80


### PR DESCRIPTION
## Purpose
- Adds the new required route for the leaderboard website team health dashboard