### PR TITLE
Sentinel Improvements

### DIFF
--- a/leaderboard/api/helm/values.yaml
+++ b/leaderboard/api/helm/values.yaml
@@ -30,6 +30,9 @@ ingress:
       - path: /api/leaderboard/challenges
         serviceName: sentinel-api-svc
         servicePort: 80
+      - path: /api/leaderboard/servicehealth
+        serviceName: sentinel-api-svc
+        servicePort: 80
       - path: /api/healthcheck/sentinel
         serviceName: sentinel-api-svc
         servicePort: 80

--- a/leaderboard/api/helm/values.yaml
+++ b/leaderboard/api/helm/values.yaml
@@ -30,6 +30,9 @@ ingress:
       - path: /api/leaderboard/challenges
         serviceName: sentinel-api-svc
         servicePort: 80
+      - path: /api/leaderboard/challengedefinitions
+        serviceName: sentinel-api-svc
+        servicePort: 80
       - path: /api/leaderboard/servicehealth
         serviceName: sentinel-api-svc
         servicePort: 80

--- a/leaderboard/sentinel/helm/templates/NOTES.txt
+++ b/leaderboard/sentinel/helm/templates/NOTES.txt
@@ -1,4 +1,4 @@
-Teams are deployed with one deployment with the 3 services. 
+This kubernetes deployment contains 4 sentinel containers in the pod correspoinding to each API for the team. 
 
 TeamID      |  ApiURL
 {{ $.Values.teams.name }}  | {{ $.Values.teams.endpointUrl }} 

--- a/provision-proctor/deploy_sentinel.sh
+++ b/provision-proctor/deploy_sentinel.sh
@@ -6,7 +6,7 @@ IFS=$'\n\t'
 # If no team is specified it will read the entries in the kvstore and deploy sentinel for the successfull ones
 # If a team is specified it will deploy sentinel only for this one
 
-usage() { echo "Usage: deploy_sentinel.sh -p <proctorEnvironmentName> -n <teamName - Optional> -f credentials.csv" 1>&2; exit 1; }
+usage() { echo "Usage: deploy_sentinel.sh -p <proctorEnvironmentName> -n <teamName - Optional> -f credentials.csv -y <localEnv - Optional>" 1>&2; exit 1; }
 
 declare -a keys
 declare registryName=""
@@ -15,9 +15,10 @@ declare teamList=""
 declare teamName=""
 declare teamEndPoint=""
 declare csvFile=""
+declare localEnv="no"
 
 # Initialize parameters specified from command line
-while getopts ":p:n:" arg; do
+while getopts ":f:p:n:y:" arg; do
     case "${arg}" in
         f)
             csvFile=${OPTARG}
@@ -27,6 +28,9 @@ while getopts ":p:n:" arg; do
         ;;
         n)
             teamName=${OPTARG}
+        ;;
+        y)
+            localEnv=${OPTARG}
         ;;
     esac
 done
@@ -38,43 +42,46 @@ if [[ -z "$proctorEnvName" ]]; then
     [[ "${proctorEnvName:?}" ]]
 fi
 
-if [[ -z "$csvFile" ]]; then
-    echo "Speficy the location of file containing the teams' Azure credentials"
-    read csvFile
-    [[ "${csvFile:?}" ]]
-fi
-
-if [ ! -f $csvFile ]; then
-    echo "File $csvFile not found"
-    exit 1
-fi
-
 chartPath="../leaderboard/sentinel/helm"
 echo -e "\nhelm install ... from: " $chartPath
 
-# Obtain the kvstore files from the teams 
-UNIQUECRED=$(awk -F, '!seen[$3]++' $csvFile)
+if [[ $localEnv == "no" ]]
 
-for cred in $UNIQUECRED
-do 
-    # echo "Line: $cred"
-    subid=$(echo $cred | awk -F ", " '{ print $3 }')
-    username=$(echo $cred | awk -F ", " '{ print $5 }')
-    password=$(echo $cred | awk -F ", " '{ print $6 }')
-    #echo "Subscription: $subid"
-    #echo "username: $username"
-    #echo "Password: $password"
-    GUID=$(echo $subid | sed -E -e 's/.{8}-.{4}-.{4}-.{4}-.{12}/guid/')
-    if [[ $GUID == "guid" ]]; then
-        az login --username=$username --password=$password > /dev/null
-        ipaddress=$(az vm list-ip-addresses --resource-group=ProctorVMRG --name=proctorVM --query "[].virtualMachine.network.publicIpAddresses[].ipAddress" -otsv)
-        if [[ $ipaddress =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            teamAAD=$(echo "$username"  | sed -e 's/.*?*@\(.*\)ops.onmicrosoft.com/\1/')
-            curl -o /home/azureuser/team_env/kvstore/$teamAAD http://${ipaddress}:2018/ohteamvalues 
-            echo "$teamAAD is at $ipaddress"
-        fi
+    if [[ -z "$csvFile" ]]; then
+        echo "Speficy the location of file containing the teams' Azure credentials"
+        read csvFile
+        [[ "${csvFile:?}" ]]
     fi
-done
+
+    if [ ! -f $csvFile ]; then
+        echo "File $csvFile not found"
+        exit 1
+    fi
+
+    # Obtain the kvstore files from the teams 
+    UNIQUECRED=$(awk -F, '!seen[$3]++' $csvFile)
+
+    for cred in $UNIQUECRED
+    do 
+        # echo "Line: $cred"
+        subid=$(echo $cred | awk -F ", " '{ print $3 }')
+        username=$(echo $cred | awk -F ", " '{ print $5 }')
+        password=$(echo $cred | awk -F ", " '{ print $6 }')
+        #echo "Subscription: $subid"
+        #echo "username: $username"
+        #echo "Password: $password"
+        GUID=$(echo $subid | sed -E -e 's/.{8}-.{4}-.{4}-.{4}-.{12}/guid/')
+        if [[ $GUID == "guid" ]]; then
+            az login --username=$username --password=$password > /dev/null
+            ipaddress=$(az vm list-ip-addresses --resource-group=ProctorVMRG --name=proctorVM --query "[].virtualMachine.network.publicIpAddresses[].ipAddress" -otsv)
+            if [[ $ipaddress =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+                teamAAD=$(echo "$username"  | sed -e 's/.*?*@\(.*\)ops.onmicrosoft.com/\1/')
+                curl -o /home/azureuser/team_env/kvstore/$teamAAD http://${ipaddress}:2018/ohteamvalues 
+                echo "$teamAAD is at $ipaddress"
+            fi
+        fi
+    done
+fi
 
 # Getting the registry name and the apiUrl from kvstore
 registryName="$(kvstore get $proctorEnvName ACR).azurecr.io"
@@ -88,14 +95,15 @@ fi
 TAG=$registryName"/devopsoh/sentinel"
 
 for team in $teamList; do
-  keys=$(kvstore keys $team)
+    if [[ $team != *"monitoring"*]]
+        keys=$(kvstore keys $team)
 
-  if [[ " ${keys[@]} " =~ "endpoint" ]]; then
-     teamEndPoint=$(kvstore get $team endpoint)
-     echo "Deploying monitoring for $team at http://$teamEndPoint"
-     helm install $chartPath --name $team --set image.repository=$TAG,teams.endpointUrl="http://$teamEndPoint",teams.apiUrl=$apiUrl,teams.name=$team
-  fi
-
+        if [[ " ${keys[@]} " =~ "endpoint" ]]; then
+            teamEndPoint=$(kvstore get $team endpoint)
+            echo "Deploying monitoring for $team at http://$teamEndPoint"
+            helm install $chartPath --name $team --set image.repository=$TAG,teams.endpointUrl="http://$teamEndPoint",teams.apiUrl=$apiUrl,teams.name=$team
+        fi
+    fi
 done
 
 


### PR DESCRIPTION
## Purpose
- Allows the ability to deploy sentinel without a CSV file when passing any string to the `-y ` script option.  This is useful when all the local `kvstore` information is already correct on the machine where running the script.
- Fixes the deploy_sentinel script missing the argument
- Skips deploying Sentinel for the monitoring environments which may be present in `kvstore ls`