### PR TITLE
Bump k8s 1.11.3, helm 2.11.0, better helm install

### DIFF
--- a/provision-proctor/deploy_ingress_dns.sh
+++ b/provision-proctor/deploy_ingress_dns.sh
@@ -11,6 +11,8 @@ usage() { echo "Usage: deploy_ingress_dns.sh -s <relative save location> -l <res
 declare relativeSaveLocation=""
 declare resourceGroupLocation=""
 declare teamName=""
+declare timeout=120  #Number of loops before timeout on check on tiller
+declare wait=5       #Number of seconds between to checks on tiller
 
 # Initialize parameters specified from command line
 while getopts ":s:l:n:" arg; do
@@ -50,21 +52,41 @@ fi
 echo -e "adding RBAC ServiceAccount and ClusterRoleBinding for tiller\n\n"
 
 kubectl create serviceaccount --namespace kube-system tillersa
+if [ $? -ne 0 ]; then
+    echo "[ERROR] Creation of tillersa failed"
+    exit 1 
+fi
 
 kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tillersa
+if [ $? -ne 0 ]; then
+    echo "[ERROR] Creation of the tiller-cluster-rule failed"
+    exit 1 
+fi
 
 kubectl create clusterrolebinding dashboard-admin --clusterrole=cluster-admin --serviceaccount=kube-system:kubernetes-dashboard
+if [ $? -ne 0 ]; then
+    echo "[ERROR] Creation of dashboard-admin failed"
+    exit 1 
+fi
 
 echo "Upgrading tiller (helm server) to match client version."
 
-helm init --upgrade --service-account tillersa --wait
+helm init --upgrade --service-account tillersa
+if [ $? -ne 0 ]; then
+    echo "[ERROR] The helm init command failed"
+    exit 1 
+fi
 
-tiller=$(kubectl get pods --all-namespaces | grep tiller | awk '{print $4}')
-
-while [ $tiller != "Running" ]; do
-        echo "Waiting for tiller ..."
-        tiller=$(kubectl get pods --all-namespaces | grep tiller | awk '{print $4}')
-        sleep 5
+count=0
+until kubectl get pods --all-namespaces | grep -E "kube-system(\s){3}tiller.*Running+"
+do
+        sleep ${wait}
+        if [ ${count} -gt ${timeout} ]; then
+            printf "Timeout - Waited %s seconds on tiller to be Running\n" "$(($count*$wait))"
+            exit 1
+        fi
+        printf "Waiting for tiller ... %s seconds\n" "$(($count*$wait))"
+        (( ++count ))
 done
 
 echo "tiller upgrade complete."

--- a/provision-team/deploy_ingress_dns.sh
+++ b/provision-team/deploy_ingress_dns.sh
@@ -11,7 +11,8 @@ usage() { echo "Usage: deploy_ingress_dns.sh -s <relative save location> -l <res
 declare relativeSaveLocation=""
 declare resourceGroupLocation=""
 declare teamName=""
-declare timeout=120  #Number of 5 seconds loop before timeout
+declare timeout=120  #Number of loops before timeout on check on tiller
+declare wait=5       #Number of seconds between to checks on tiller
 
 # Initialize parameters specified from command line
 while getopts ":s:l:n:" arg; do
@@ -79,12 +80,12 @@ fi
 count=0
 until kubectl get pods --all-namespaces | grep -E "kube-system(\s){3}tiller.*Running+"
 do
-        sleep 5
-        if [ $count -gt $timeout ]; then
-            printf "Timeout - Waited %s times 5 seconds on tiller to be Running\n" "$count"
+        sleep ${wait}
+        if [ ${count} -gt ${timeout} ]; then
+            printf "Timeout - Waited %s seconds on tiller to be Running\n" "$(($count*$wait))"
             exit 1
         fi
-        printf "Waiting for tiller ...\n"
+        printf "Waiting for tiller ... %s seconds\n" "$(($count*$wait))"
         (( ++count ))
 done
 

--- a/provision-team/provision_aks.sh
+++ b/provision-team/provision_aks.sh
@@ -108,7 +108,7 @@ fi
 echo "Creating AKS Cluster..."
 (
     set -x
-    az aks create -g $resourceGroupName -n $clusterName -l $resourceGroupLocation --node-count 3 --generate-ssh-keys -k 1.11.2 --service-principal $SP_ID --client-secret $SP_PASS
+    az aks create -g $resourceGroupName -n $clusterName -l $resourceGroupLocation --node-count 3 --generate-ssh-keys -k 1.11.3 --service-principal $SP_ID --client-secret $SP_PASS
 )
 
 if [ $? == 0 ];

--- a/provision-vm/proctorVMSetup.sh
+++ b/provision-vm/proctorVMSetup.sh
@@ -31,13 +31,13 @@ sudo add-apt-repository "deb [arch=amd64] https://packages.microsoft.com/ubuntu/
 # Add Docker source
 sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable"
 
-echo "############### Installing Helm v2.10.0 ###############"
-sudo curl -s -O https://storage.googleapis.com/kubernetes-helm/helm-v2.10.0-linux-amd64.tar.gz
-sudo tar -zxvf helm-v2.10.0-linux-amd64.tar.gz
+echo "############### Installing Helm v2.11.0 ###############"
+sudo curl -s -O https://storage.googleapis.com/kubernetes-helm/helm-v2.11.0-linux-amd64.tar.gz
+sudo tar -zxvf helm-v2.11.0-linux-amd64.tar.gz
 sudo mv linux-amd64/helm /usr/local/bin/helm
 
 echo "############### Installing kubectl ###############"
-curl -s -LO https://storage.googleapis.com/kubernetes-release/release/v1.11.2/bin/linux/amd64/kubectl
+curl -s -LO https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubectl
 chmod +x ./kubectl
 sudo mv ./kubectl /usr/local/bin/kubectl
 
@@ -45,7 +45,7 @@ echo "############### Installing Packages ###############"
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get update 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y dotnet-sdk-2.1 jq git zip azure-cli=2.0.45-1~xenial
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y dotnet-sdk-2.1 jq git zip azure-cli=2.0.49-1~xenial
 sudo DEBIAN_FRONTEND=noninteractive ACCEPT_EULA=Y apt-get install -y mssql-tools unixodbc-dev
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce
 


### PR DESCRIPTION
## Purpose
Bump minor versions for the packages for the following reasons:

- kubernetes cli and AKS [1.11.2 --> 1.11.3](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.11.md#changelog-since-v1112)
This is most important: `the API server and client-go libraries have been fixed to support additional non-alpha-numeric characters in UserInfo "extra" data keys. Both should be updated in order to properly support extra data containing "/" characters or other characters disallowed in HTTP headers. `
> Note 1.11.4 available upstream, but not on AKS yet.

- Helm 2.10.0 --> 2.11.0
The tiller does a check using the kubectl client via [this go file](https://github.com/helm/helm/blob/master/pkg/kube/client.go).
There are quite a few package updates with this client included in Helm 2.11.0 which may have also helped remove or reduce the load/issues against the watches/queries to the master.

- az 2.0.45 (August 29th 2018) --> 2.0.49 (October 24th 2018)
improvements and bugfix history:
[acr](https://github.com/Azure/azure-cli/commits/dev/src/command_modules/azure-cli-acr)
[aks](https://github.com/Azure/azure-cli/commits/master/src/command_modules/azure-cli-acs)
[keyvault](https://github.com/Azure/azure-cli/commits/dev/src/command_modules/azure-cli-keyvault)
[sql](https://github.com/Azure/azure-cli/commits/dev/src/command_modules/azure-cli-sql)
[vm](https://github.com/Azure/azure-cli/commits/dev/src/command_modules/azure-cli-vm)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```