### PR TITLE
Fix tiller regex ready

### DIFF
--- a/provision-team/deploy_ingress_dns.sh
+++ b/provision-team/deploy_ingress_dns.sh
@@ -78,7 +78,7 @@ if [ $? -ne 0 ]; then
 fi
 
 count=0
-until kubectl get pods --all-namespaces | grep -E "kube-system(\s){3}tiller.*Running+"
+until kubectl get pods --all-namespaces | grep -E "kube-system.*tiller.*1\/1.*Running+"
 do
         sleep ${wait}
         if [ ${count} -gt ${timeout} ]; then


### PR DESCRIPTION
## Purpose
Tiller was able to be in a state where you see "Running" but the pod is not actually ready.  This makes the following regex improvements:
* it any number of characters after `kube-system` versus specifically check for 3 whitespace characters
* it checks for `1/1` after tiller to ensure the pod is ready and running

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```