### PR TITLE
Fix proctorVM minor issues for nologin branch

### DIFF
--- a/provision-team/README.md
+++ b/provision-team/README.md
@@ -10,9 +10,11 @@ The required pre-requisites for installing a team environment are installed as p
 
 ## Usage
 
-    `nohup ./setup.sh -i <subscriptionId> -l <resourceGroupLocation> -n <teamName> -e <teamNumber> ><teamName><teamNumber>.out &`
+**NOTE**: Prior to executing the setup script below for a team, you must login against the target subscription. Skip it if you have already done so using the azure cli.
 
-**NOTE: You must login against the target subscription, if you have not already done so using the azure cli, prior to executing the setup script for a team.**
+**NOTE**: Do not run this command as root (`sudo su` or `sudo [command]`). Run it using the standard user.
+
+    `nohup ./setup.sh -i <subscriptionId> -l <resourceGroupLocation> -n <teamName> -e <teamNumber> ><teamName><teamNumber>.out &`
 
 ### Parameters
 

--- a/provision-vm/proctorVMSetup.sh
+++ b/provision-vm/proctorVMSetup.sh
@@ -50,11 +50,15 @@ sudo DEBIAN_FRONTEND=noninteractive ACCEPT_EULA=Y apt-get install -y mssql-tools
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce
 
 touch /home/azureuser/.bashrc
-echo 'export PATH=$PATH:/opt/mssql-tools/bin' >> /home/azureuser/.bashrc
+sudo ln -sfn /opt/mssql-tools/bin/sqlcmd /usr/bin/sqlcmd
+sudo ln -sfn /opt/mssql-tools/bin/bcp /usr/bin/bcp
 
 echo "############### Pulling Openhack-tools from Github ###############"
 sudo git clone https://github.com/Azure-Samples/openhack-devops-proctor.git /home/azureuser/openhack-devops-proctor
 sudo chown azureuser:azureuser -R /home/azureuser/openhack-devops-proctor/.
+# For nologin deployment, check out the nologin branch
+cd /home/azureuser/openhack-devops-proctor
+git checkout nologin
 
 echo "############### Install kvstore ###############"
 sudo install -b /home/azureuser/openhack-devops-proctor/provision-team/kvstore.sh /usr/local/bin/kvstore


### PR DESCRIPTION
I'm running some experiments for the DevOps OpenHack and while setting it up on my internal subscription, I've been through some issues to provision the team environment from the proctorVM.

Those changes are based on this experience I had and they helped me have the team environment provisioned.

## Purpose
Improve the experience on provisioning the environment on an internal subscription by using the *nologin* branch.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
### Get the code
```
git clone https://github.com/ricardoserradas/openhack-devops-proctor.git
cd openhack-devops-proctor
git checkout fix/provision-vm
cd provision-vm
```
### Test the code
* Change *nologindeploy.json* (line 195, property *fileUris*) to `https://raw.githubusercontent.com/ricardoserradas/openhack-devops-proctor/fix/provision-vm/provision-vm/proctorVMSetup.sh`.
* Follow instructions from [here](https://github.com/ricardoserradas/openhack-devops-proctor/tree/fix/provision-vm/provision-vm)

## What to Check
* Connect to the proctorVM and check:
  * If the branch *nologin* is already checked out on `/home/azureuser/openhack-devops-proctor`
  * Try to run both *sqlcmd* and *bcp* commands from anywhere inside the machine
  * Run *setup.sh* inside `/home/azureuser/openhack-devops-proctor/provision-team`, according to the [default instructions](https://github.com/Azure-Samples/openhack-devops-proctor/tree/nologin/provision-team).

## Other Information
When running *setup.sh* as root, it tries to use some paths from the root user instead of azureuser, causing errors during the setup. That's why I added the instruction to not use root to run the setup.