### PR TITLE
Enabling docker for proctor vm deployment

### DIFF
--- a/provision-team/cleanup_environment.sh
+++ b/provision-team/cleanup_environment.sh
@@ -28,18 +28,18 @@ fi
 
 # Copy the kubeconfig file
 kubeconfiglocation="/home/azureuser/team_env/$teamName/kubeconfig-$teamName"
-sudo cp /root/.kube/config /home/azureuser/www/kubeconfig
-sudo cp /root/.kube/config $kubeconfiglocation
+cp /root/.kube/config /home/azureuser/www/kubeconfig
+cp /root/.kube/config $kubeconfiglocation
 echo "Copied the kubeconfig file to $kubeconfiglocation"
 
 kvstore set $teamName kubeconfig $kubeconfiglocation
 kvstore set $teamName zippassword $password
 
 # Setup files to serve via nginx
-sudo cp /home/azureuser/team_env/kvstore/${teamName} /home/azureuser/www/ohteamvalues
-sudo zip -e --password ${password} /home/azureuser/www/teamfiles.zip /home/azureuser/www/kubeconfig /home/azureuser/www/ohteamvalues
+cp /home/azureuser/team_env/kvstore/${teamName} /home/azureuser/www/ohteamvalues
+zip -e --password ${password} /home/azureuser/www/teamfiles.zip /home/azureuser/www/kubeconfig /home/azureuser/www/ohteamvalues
 echo "Zipped /home/azureuser/www/teamfiles.zip with password $password"
-sudo cp /home/azureuser/openhack-devops-proctor/provision-team/nginx/index.html /home/azureuser/www/index.html
+cp /home/azureuser/openhack-devops-proctor/provision-team/nginx/index.html /home/azureuser/www/index.html
 
 # Set proper ownership for the regular user after script completes
-sudo chown -R azureuser:azureuser /home/azureuser
+# chown -R azureuser:azureuser /home/azureuser

--- a/provision-team/run_nginx.sh
+++ b/provision-team/run_nginx.sh
@@ -10,4 +10,4 @@ if [[ ! -d "/home/azureuser/www" ]]; then
 fi 
 
 # Add nginx to the script
-sudo docker run --restart always -v /home/azureuser/openhack-devops-proctor/provision-team/nginx/:/etc/nginx/conf.d/ -v /home/azureuser/www/:/usr/share/nginx/html -p 2018:80 -d nginx
+docker run --restart always -v /home/azureuser/openhack-devops-proctor/provision-team/nginx/:/etc/nginx/conf.d/ -v /home/azureuser/www/:/usr/share/nginx/html -p 2018:80 -d nginx

--- a/provision-vm/Docker/Dockerfile
+++ b/provision-vm/Docker/Dockerfile
@@ -59,8 +59,10 @@ RUN echo 'export PATH=$PATH:/opt/mssql-tools/bin' >> /home/azureuser/.bashrc
 RUN git clone https://github.com/Azure-Samples/openhack-devops-proctor.git /home/azureuser/openhack-devops-proctor
 # RUN chown azureuser:azureuser -R /home/azureuser/openhack-devops-proctor/.
 
-##### TODO This line will be removed before the PR merged
+##### TODO This line will be removed before the PR merged 
+WORKDIR /home/azureuser/openhack-devops-proctor
 RUN git checkout -b refactor/provisionvm origin/refactor/provisionvm
+WORKDIR ${home}
 
 ############### Install kvstore ###############
 RUN install -b /home/azureuser/openhack-devops-proctor/provision-team/kvstore.sh /usr/local/bin/kvstore

--- a/provision-vm/Docker/Dockerfile
+++ b/provision-vm/Docker/Dockerfile
@@ -83,6 +83,7 @@ ENV KVSTORE_DIR /home/azureuser/team_env/kvstore
 ENV DOCKER_HOST tcp://docker:2375
 
 COPY startup.sh .
+RUN chmod +x /home/azureuser/startup.sh
 CMD ["/bin/bash", "-c", "/home/azureuser/startup.sh"]
 
 

--- a/provision-vm/Docker/Dockerfile
+++ b/provision-vm/Docker/Dockerfile
@@ -1,0 +1,86 @@
+From ubuntu:16.04
+
+############### Adding package respositories ###############
+ENV home /home/azureuser
+RUN mkdir -p ${home}
+WORKDIR ${home}
+
+RUN apt-get update
+RUN apt-get install -y gnupg
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y  apt-utils curl
+RUN apt-get install software-properties-common -y
+
+# Get the Microsoft signing key 
+RUN curl -L https://packages.microsoft.com/keys/microsoft.asc 2>&1 | apt-key add -
+
+# Get the Docker GPG key 
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg 2>&1 | apt-key add -
+# sudo apt-key adv --keyserver packages.microsoft.com --recv-keys 52E16F86FEE04B979B07E28DB02C46DF417A0893
+
+# Azure-cli
+RUN add-apt-repository "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ xenial main"
+# Dotnet SDK v2.1
+RUN add-apt-repository "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-xenial-prod xenial main"
+# Add MSSQL source 
+RUN add-apt-repository "deb [arch=amd64] https://packages.microsoft.com/ubuntu/16.04/prod xenial main"
+# Add Docker source
+RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable"
+
+############### Installing Helm v2.12.2 ###############
+RUN curl -s -O https://storage.googleapis.com/kubernetes-helm/helm-v2.12.2-linux-amd64.tar.gz
+RUN tar -zxvf helm-v2.12.2-linux-amd64.tar.gz
+RUN mv linux-amd64/helm /usr/local/bin/helm
+
+############### Installing kubectl ###############
+RUN curl -s -LO https://storage.googleapis.com/kubernetes-release/release/v1.11.7/bin/linux/amd64/kubectl
+RUN chmod +x ./kubectl
+RUN mv ./kubectl /usr/local/bin/kubectl
+
+############### Installing Packages ###############
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https
+RUN DEBIAN_FRONTEND=noninteractive apt-get update 
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y dotnet-sdk-2.2 jq git zip azure-cli=2.0.49-1~xenial
+RUN DEBIAN_FRONTEND=noninteractive ACCEPT_EULA=Y apt-get install -y mssql-tools unixodbc-dev
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce
+
+############### Locale Settings ###############
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y locales
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
+ENV LANG en_US.UTF-8  
+ENV LANGUAGE en_US:en  
+ENV LC_ALL en_US.UTF-8 
+
+RUN touch /home/azureuser/.bashrc
+RUN echo 'export PATH=$PATH:/opt/mssql-tools/bin' >> /home/azureuser/.bashrc
+
+############### Pulling Openhack-tools from Github ###############
+RUN git clone https://github.com/Azure-Samples/openhack-devops-proctor.git /home/azureuser/openhack-devops-proctor
+# RUN chown azureuser:azureuser -R /home/azureuser/openhack-devops-proctor/.
+
+##### TODO This line will be removed before the PR merged
+RUN git checkout -b refactor/provisionvm origin/refactor/provisionvm
+
+############### Install kvstore ###############
+RUN install -b /home/azureuser/openhack-devops-proctor/provision-team/kvstore.sh /usr/local/bin/kvstore
+RUN echo 'export KVSTORE_DIR=/home/azureuser/team_env/kvstore' >> /home/azureuser/.bashrc
+
+RUN echo azure-cli hold | dpkg --set-selections
+
+#Add user to docker usergroup
+RUN usermod -aG docker root
+
+#Holding walinuxagent before upgrade
+RUN apt-mark hold walinuxagent
+RUN DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
+
+#Set environement variables
+ENV PATH $PATH:/opt/mssql-tools/bin
+ENV KVSTORE_DIR /home/azureuser/team_env/kvstore
+ENV DOCKER_HOST tcp://docker:2375
+
+COPY startup.sh .
+CMD ["/bin/bash", "-c", "startup.sh"]
+
+

--- a/provision-vm/Docker/Dockerfile
+++ b/provision-vm/Docker/Dockerfile
@@ -83,6 +83,6 @@ ENV KVSTORE_DIR /home/azureuser/team_env/kvstore
 ENV DOCKER_HOST tcp://docker:2375
 
 COPY startup.sh .
-CMD ["/bin/bash", "-c", "startup.sh"]
+CMD ["/bin/bash", "-c", "/home/azureuser/startup.sh"]
 
 

--- a/provision-vm/Docker/Readme.md
+++ b/provision-vm/Docker/Readme.md
@@ -1,0 +1,30 @@
+# Docker support for provision vm
+
+We are migrating the provision environment from Ubuntu VM to a doocker container.
+It helps us to solve these problem. Currently, experimental.
+
+* Deployment fails because of the upgrade of the apt packages. 
+* We can deploy only from Ubuntu environment. 
+
+# Get Started
+
+For getting started, create a docker daemon using the docker image. For experimental purpose, 
+Currently only support manual deployment for testing.
+
+```
+$ docker run -d --name some-docker --privileged docker:stable-dind
+$ docker run --link some-docker:docker -it proctorvm /bin/bash
+root@531ed021c2c5:/home/azureuser# export DOCKER_HOST='tcp://docker:2375'
+root@531ed021c2c5:/home/azureuser# export AZUREUSERNAME=YOUR_SERVICE_PRINICPAL_NAME
+root@531ed021c2c5:/home/azureuser# export AZUREPASSWORD=YOUR_SERVICE_PRINICPAL_PASSWORD
+root@531ed021c2c5:/home/azureuser# export SUBID=YOUR_SUBSCRIPTION_ID
+root@531ed021c2c5:/home/azureuser# export LOCATION=westus2
+root@531ed021c2c5:/home/azureuser# export TEAMNAME=YOUR_TEAM_NAME (e.g. ushioh)
+root@531ed021c2c5:/home/azureuser# export RECIPIENTEMAIL=YOUR_E_MAIL
+root@531ed021c2c5:/home/azureuser# export CHATCONNECTIONSTRING=null 
+root@531ed021c2c5:/home/azureuser# export CHATMESSAGEQUEUE=null
+root@531ed021c2c5:/home/azureuser# export TENANTID=YOUR_TENANT_ID
+root@531ed021c2c5:/home/azureuser# export APPID=YOUR_SERVICE_PRINICPAL_APP_ID
+root@531ed021c2c5:/home/azureuser# chmod +x ./startup.sh
+root@531ed021c2c5:/home/azureuser# ./start.sh
+```

--- a/provision-vm/Docker/startup.sh
+++ b/provision-vm/Docker/startup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+echo "############### Azure credentials ###############"
+echo "UserName: $AZUREUSERNAME"
+echo "Password: $AZUREPASSWORD"
+echo "Subscription ID: $SUBID"
+echo "Location: $LOCATION"
+echo "Team Name: $TEAMNAME"
+echo "Recipient email: $RECIPIENTEMAIL"
+echo "ChatConnectionString= $CHATCONNECTIONSTRING"
+echo "ChatConnectionQueue= $CHATMESSAGEQUEUE"
+echo "Tenant is $TENANTID"
+echo "AppId is $APPID"
+
+cd /home/azureuser/openhack-devops-proctor/provision-team
+
+# Running the provisioning of the team environment
+
+if [[ -z "$TENANTID" ]]; then
+    az login --username=$AZUREUSERNAME --password=$AZUREPASSWORD
+else
+    az login --service-principal --username=$AZUREUSERNAME --password=$AZUREPASSWORD --tenant=$TENANTID
+fi 
+
+
+# Launching the team provisioning in background
+PATH=$PATH:/opt/mssql-tools/bin KVSTORE_DIR=/home/azureuser/team_env/kvstore nohup ./setup.sh -i $SUBID -l $LOCATION -n $TEAMNAME -u "$AZUREUSERNAME" -p "$AZUREPASSWORD" -r "$RECIPIENTEMAIL" -c "$CHATCONNECTIONSTRING" -q "$CHATMESSAGEQUEUE" -t "$TENANTID" -a "$APPID" >teamdeploy.out &

--- a/provision-vm/Docker/startup.sh
+++ b/provision-vm/Docker/startup.sh
@@ -24,4 +24,4 @@ fi
 
 
 # Launching the team provisioning in background
-PATH=$PATH:/opt/mssql-tools/bin KVSTORE_DIR=/home/azureuser/team_env/kvstore nohup ./setup.sh -i $SUBID -l $LOCATION -n $TEAMNAME -u "$AZUREUSERNAME" -p "$AZUREPASSWORD" -r "$RECIPIENTEMAIL" -c "$CHATCONNECTIONSTRING" -q "$CHATMESSAGEQUEUE" -t "$TENANTID" -a "$APPID" >teamdeploy.out &
+PATH=$PATH:/opt/mssql-tools/bin KVSTORE_DIR=/home/azureuser/team_env/kvstore ./setup.sh -i $SUBID -l $LOCATION -n $TEAMNAME -u "$AZUREUSERNAME" -p "$AZUREPASSWORD" -r "$RECIPIENTEMAIL" -c "$CHATCONNECTIONSTRING" -q "$CHATMESSAGEQUEUE" -t "$TENANTID" -a "$APPID"

--- a/provision-vm/azuredeploy.json
+++ b/provision-vm/azuredeploy.json
@@ -239,7 +239,7 @@
                 "autoUpgradeMinorVersion": true,
                 "settings": {
                     "fileUris": [
-                        "https://raw.githubusercontent.com/Azure-Samples/openhack-devops-proctor/master/provision-vm/proctorVMSetup.sh"
+                        "https://raw.githubusercontent.com/Azure-Samples/openhack-devops-proctor/refactor/provisionvm/provision-vm/proctorVMSetup.sh"
                     ],
                     "commandToExecute": "[concat('sh proctorVMSetup.sh', ' ', variables('azureUserName'), ' ', variables('singleQuote'), variables('azurePassword'), variables('singleQuote'), ' ', subscription().subscriptionId, ' ', resourceGroup().location, ' ', variables('teamName'), ' ', variables('recipientEmail'), ' ', variables('singleQuote'), variables('ChatConnectionString'), variables('singleQuote'), ' ', variables('singleQuote'), variables('ChatMessageQueue'), variables('singleQuote'), ' ', variables('azureTenant'), ' ', variables('azureAppId') )]"
                 }

--- a/provision-vm/proctorVMSetup.sh
+++ b/provision-vm/proctorVMSetup.sh
@@ -55,5 +55,5 @@ echo "AppId is $APPID"
 # Launching the team provisioning in background
 
 /bin/bash -c 'docker run -d --name docker-daemon --privileged docker:stable-dind &'
-/bin/bash -c 'docker run tsuyoshiushio/proctor-container --link docker-daemon:docker -d -e  "AZUREUSERNAME=$AZUREUSERNAME" -e "AZUREPASSWORD=$AZUREPASSWORD" -e "SUBID=$SUBID" -e "LOCATION=$LOCATION" -e "TEAMNAME=$TEAMNAME" -e "RECIPIENTEMAIL=$RECIPIENTEMAIL" -e "CHATCONNECTIONSTRING=$CHATCONNECTIONSTRING" -e "CHATMESSAGEQUEUE=$CHATMESSAGEQUEUE" -e "TENANTID=$TENANTID" -e "APPID=$APPID" > teamdeploy.out &'
+/bin/bash -c 'docker run --link docker-daemon:docker -d -e  "AZUREUSERNAME=$AZUREUSERNAME" -e "AZUREPASSWORD=$AZUREPASSWORD" -e "SUBID=$SUBID" -e "LOCATION=$LOCATION" -e "TEAMNAME=$TEAMNAME" -e "RECIPIENTEMAIL=$RECIPIENTEMAIL" -e "CHATCONNECTIONSTRING=$CHATCONNECTIONSTRING" -e "CHATMESSAGEQUEUE=$CHATMESSAGEQUEUE" -e "TENANTID=$TENANTID" -e "APPID=$APPID" tsuyoshiushio/proctor-container  > teamdeploy.out &'
 echo "############### End of custom script ###############"

--- a/provision-vm/proctorVMSetup.sh
+++ b/provision-vm/proctorVMSetup.sh
@@ -54,5 +54,6 @@ echo "AppId is $APPID"
 
 # Launching the team provisioning in background
 
-/bin/bash -c 'docker run tsuyoshiushio/proctor-container -d -e  "AZUREUSERNAME=$AZUREUSERNAME" -e "AZUREPASSWORD=$AZUREPASSWORD" -e "SUBID=$SUBID" -e "LOCATION=$LOCATION" -e "TEAMNAME=$TEAMNAME" -e "RECIPIENTEMAIL=$RECIPIENTEMAIL" -e "CHATCONNECTIONSTRING=$CHATCONNECTIONSTRING" -e "CHATMESSAGEQUEUE=$CHATMESSAGEQUEUE" -e "TENANTID=$TENANTID" -e "APPID=$APPID" > teamdeploy.out &'
+/bin/bash -c 'docker run -d --name docker-daemon --privileged docker:stable-dind &'
+/bin/bash -c 'docker run tsuyoshiushio/proctor-container --link docker-daemon:docker -d -e  "AZUREUSERNAME=$AZUREUSERNAME" -e "AZUREPASSWORD=$AZUREPASSWORD" -e "SUBID=$SUBID" -e "LOCATION=$LOCATION" -e "TEAMNAME=$TEAMNAME" -e "RECIPIENTEMAIL=$RECIPIENTEMAIL" -e "CHATCONNECTIONSTRING=$CHATCONNECTIONSTRING" -e "CHATMESSAGEQUEUE=$CHATMESSAGEQUEUE" -e "TENANTID=$TENANTID" -e "APPID=$APPID" > teamdeploy.out &'
 echo "############### End of custom script ###############"

--- a/provision-vm/proctorVMSetup.sh
+++ b/provision-vm/proctorVMSetup.sh
@@ -54,6 +54,17 @@ echo "AppId is $APPID"
 
 # Launching the team provisioning in background
 
+export AZUREUSERNAME=$AZUREUSERNAME
+export AZUREPASSWORD=$AZUREPASSWORD
+export SUBID=$SUBID
+export LOCATION=$LOCATION
+export TEAMNAME=$TEAMNAME
+export RECIPIENTEMAIL=$RECIPIENTEMAIL
+export CHATCONNECTIONSTRING=$CHATCONNECTIONSTRING
+export CHATMESSAGEQUEUE=$CHATMESSAGEQUEUE
+export TENANTID=$TENANTID
+export APPID=$APPID
+
 /bin/bash -c 'docker run -d --name docker-daemon --privileged docker:stable-dind &'
-/bin/bash -c 'docker run --link docker-daemon:docker -d -e  "AZUREUSERNAME=$AZUREUSERNAME" -e "AZUREPASSWORD=$AZUREPASSWORD" -e "SUBID=$SUBID" -e "LOCATION=$LOCATION" -e "TEAMNAME=$TEAMNAME" -e "RECIPIENTEMAIL=$RECIPIENTEMAIL" -e "CHATCONNECTIONSTRING=$CHATCONNECTIONSTRING" -e "CHATMESSAGEQUEUE=$CHATMESSAGEQUEUE" -e "TENANTID=$TENANTID" -e "APPID=$APPID" tsuyoshiushio/proctor-container  > teamdeploy.out &'
+/bin/bash -c 'docker run --link docker-daemon:docker -d -e  AZUREUSERNAME -e AZUREPASSWORD -e SUBID -e LOCATION -e TEAMNAME -e RECIPIENTEMAIL -e CHATCONNECTIONSTRING -e CHATMESSAGEQUEUE -e TENANTID -e APPID tsuyoshiushio/proctor-container  > teamdeploy.out &'
 echo "############### End of custom script ###############"

--- a/provision-vm/proctorVMSetup.sh
+++ b/provision-vm/proctorVMSetup.sh
@@ -54,5 +54,5 @@ echo "AppId is $APPID"
 
 # Launching the team provisioning in background
 
-/bin/bash docker run tsuyoshiushio/proctor-container -d -e  "AZUREUSERNAME=$AZUREUSERNAME" -e "AZUREPASSWORD=$AZUREPASSWORD" -e "SUBID=$SUBID" -e "LOCATION=$LOCATION" -e "TEAMNAME=$TEAMNAME" -e "RECIPIENTEMAIL=$RECIPIENTEMAIL" -e "CHATCONNECTIONSTRING=$CHATCONNECTIONSTRING" -e "CHATMESSAGEQUEUE=$CHATMESSAGEQUEUE" -e "TENANTID=$TENANTID" -e "APPID=$APPID" > teamdeploy.out &
+/bin/bash -c 'docker run tsuyoshiushio/proctor-container -d -e  "AZUREUSERNAME=$AZUREUSERNAME" -e "AZUREPASSWORD=$AZUREPASSWORD" -e "SUBID=$SUBID" -e "LOCATION=$LOCATION" -e "TEAMNAME=$TEAMNAME" -e "RECIPIENTEMAIL=$RECIPIENTEMAIL" -e "CHATCONNECTIONSTRING=$CHATCONNECTIONSTRING" -e "CHATMESSAGEQUEUE=$CHATMESSAGEQUEUE" -e "TENANTID=$TENANTID" -e "APPID=$APPID" > teamdeploy.out &'
 echo "############### End of custom script ###############"


### PR DESCRIPTION
We had an issue for deployment of the proctor vm. It is caused by library download. Talking with Damien, we is going to make it to the container. Then it might be no problem for the downloading the library. Also it might be handy for the people. 

I open this PR to talk about the design. 

This is just the first version for enabling container work on docker. 

I wrote a README on the proctor-vm/Docker/Readme for testing Docker solution. 
When I execute the script of team environment, it works. 

# Done 

* Create a startup script and Dockerfile
* Change some scripts to make it work on container (remove sudo)

# TODO

* Refactor the script to make it production grade
* Change the proctorVMSetup.sh for installing only docker
* Upload the docker image to the DockerHub and automate the process. 
* Use Volume to keep the logs and assets to debugging 
* Come up with the solution for nginx deployment and expose port






