### PR TITLE
fix: returns 404 even if it is 200

### DIFF
--- a/resources/polling.sh
+++ b/resources/polling.sh
@@ -43,7 +43,7 @@ fi
 
 healthcheck() {
     declare url=$1
-    result=$(curl -I $url 2>/dev/null | grep HTTP/1.1)
+    result=$(curl -i $url 2>/dev/null | grep HTTP/1.1)
     echo $result
 }
 


### PR DESCRIPTION
Healthcheck URl doesn't work for `-I` which means 

```
-I, --head

(HTTP FTP FILE) Fetch the headers only! HTTP-servers feature the command HEAD which this uses to get nothing but the header of a document. When used on an FTP or FILE file, curl displays the file size and last modification time only.
```

it is fix the current issue to change it '-i'. However I'm wondering why it doesn't work for the health check. (I'd like to know why it happens for the learning)