### PR TITLE
Fix: error of deploying proctorVM

### DIFF
--- a/provision-vm/azuredeploy.json
+++ b/provision-vm/azuredeploy.json
@@ -239,7 +239,7 @@
                 "autoUpgradeMinorVersion": true,
                 "settings": {
                     "fileUris": [
-                        "https://raw.githubusercontent.com/Azure-Samples/openhack-devops-proctor/master/provision-vm/proctorVMSetup.sh"
+                        "https://raw.githubusercontent.com/Azure-Samples/openhack-devops-proctor/fix/debconf/provision-vm/proctorVMSetup.sh"
                     ],
                     "commandToExecute": "[concat('sh proctorVMSetup.sh', ' ', variables('azureUserName'), ' ', variables('singleQuote'), variables('azurePassword'), variables('singleQuote'), ' ', subscription().subscriptionId, ' ', resourceGroup().location, ' ', variables('teamName'), ' ', variables('recipientEmail'), ' ', variables('singleQuote'), variables('ChatConnectionString'), variables('singleQuote'), ' ', variables('singleQuote'), variables('ChatMessageQueue'), variables('singleQuote'), ' ', variables('azureTenant'), ' ', variables('azureAppId') )]"
                 }

--- a/provision-vm/azuredeploy.json
+++ b/provision-vm/azuredeploy.json
@@ -239,7 +239,7 @@
                 "autoUpgradeMinorVersion": true,
                 "settings": {
                     "fileUris": [
-                        "https://raw.githubusercontent.com/Azure-Samples/openhack-devops-proctor/fix/debconf/provision-vm/proctorVMSetup.sh"
+                        "https://raw.githubusercontent.com/Azure-Samples/openhack-devops-proctor/master/provision-vm/proctorVMSetup.sh"
                     ],
                     "commandToExecute": "[concat('sh proctorVMSetup.sh', ' ', variables('azureUserName'), ' ', variables('singleQuote'), variables('azurePassword'), variables('singleQuote'), ' ', subscription().subscriptionId, ' ', resourceGroup().location, ' ', variables('teamName'), ' ', variables('recipientEmail'), ' ', variables('singleQuote'), variables('ChatConnectionString'), variables('singleQuote'), ' ', variables('singleQuote'), variables('ChatMessageQueue'), variables('singleQuote'), ' ', variables('azureTenant'), ' ', variables('azureAppId') )]"
                 }

--- a/provision-vm/proctorVMSetup.sh
+++ b/provision-vm/proctorVMSetup.sh
@@ -73,5 +73,5 @@ mkdir -p /home/nginx/contents
 mkdir -p /home/azureuser/logs
 
 # /bin/bash -c 'docker run -d --name docker-daemon --privileged docker:stable-dind &'
-/bin/bash -c 'docker run --mount '"'"'type=bind,src=/home/nginx/config,dst=/home/nginx/config'"'"' --mount '"'"'type=bind,src=/home/nginx/contents,dst=/home/nginx/contents'"'"' --mount '"'"'type=bind,src=/home/azureuser/logs,dst=/home/azureuser/logs'"'"' -v /var/run/docker.sock:/var/run/docker.sock -d -e  AZUREUSERNAME -e AZUREPASSWORD -e SUBID -e LOCATION -e TEAMNAME -e RECIPIENTEMAIL -e CHATCONNECTIONSTRING -e CHATMESSAGEQUEUE -e TENANTID -e APPID devopsoh/proctor-container &'
+# /bin/bash -c 'docker run --mount '"'"'type=bind,src=/home/nginx/config,dst=/home/nginx/config'"'"' --mount '"'"'type=bind,src=/home/nginx/contents,dst=/home/nginx/contents'"'"' --mount '"'"'type=bind,src=/home/azureuser/logs,dst=/home/azureuser/logs'"'"' -v /var/run/docker.sock:/var/run/docker.sock -d -e  AZUREUSERNAME -e AZUREPASSWORD -e SUBID -e LOCATION -e TEAMNAME -e RECIPIENTEMAIL -e CHATCONNECTIONSTRING -e CHATMESSAGEQUEUE -e TENANTID -e APPID devopsoh/proctor-container &'
 #echo "############### End of custom script ###############"

--- a/provision-vm/proctorVMSetup.sh
+++ b/provision-vm/proctorVMSetup.sh
@@ -34,7 +34,8 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-commo
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io
 
 #Add user to docker usergroup
-# sudo usermod -aG docker azureuser
+sudo DEBIAN_FRONTEND=noninteractive apt-get remove -y unscd 
+sudo usermod -aG docker azureuser
 
 #Holding walinuxagent before upgrade
 sudo DEBIAN_FRONTEND=noninteractive apt-mark hold walinuxagent

--- a/provision-vm/proctorVMSetup.sh
+++ b/provision-vm/proctorVMSetup.sh
@@ -34,11 +34,11 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-commo
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io
 
 #Add user to docker usergroup
-sudo usermod -aG docker azureuser
+# sudo usermod -aG docker azureuser
 
 #Holding walinuxagent before upgrade
-sudo apt-mark hold walinuxagent
-sudo apt-get upgrade -y
+sudo DEBIAN_FRONTEND=noninteractive apt-mark hold walinuxagent
+sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
 
 echo "############### Azure credentials ###############"
 echo "UserName: $AZUREUSERNAME"

--- a/provision-vm/proctorVMSetup.sh
+++ b/provision-vm/proctorVMSetup.sh
@@ -74,5 +74,5 @@ mkdir -p /home/nginx/contents
 mkdir -p /home/azureuser/logs
 
 # /bin/bash -c 'docker run -d --name docker-daemon --privileged docker:stable-dind &'
-# /bin/bash -c 'docker run --mount '"'"'type=bind,src=/home/nginx/config,dst=/home/nginx/config'"'"' --mount '"'"'type=bind,src=/home/nginx/contents,dst=/home/nginx/contents'"'"' --mount '"'"'type=bind,src=/home/azureuser/logs,dst=/home/azureuser/logs'"'"' -v /var/run/docker.sock:/var/run/docker.sock -d -e  AZUREUSERNAME -e AZUREPASSWORD -e SUBID -e LOCATION -e TEAMNAME -e RECIPIENTEMAIL -e CHATCONNECTIONSTRING -e CHATMESSAGEQUEUE -e TENANTID -e APPID devopsoh/proctor-container &'
+/bin/bash -c 'docker run --mount '"'"'type=bind,src=/home/nginx/config,dst=/home/nginx/config'"'"' --mount '"'"'type=bind,src=/home/nginx/contents,dst=/home/nginx/contents'"'"' --mount '"'"'type=bind,src=/home/azureuser/logs,dst=/home/azureuser/logs'"'"' -v /var/run/docker.sock:/var/run/docker.sock -d -e  AZUREUSERNAME -e AZUREPASSWORD -e SUBID -e LOCATION -e TEAMNAME -e RECIPIENTEMAIL -e CHATCONNECTIONSTRING -e CHATMESSAGEQUEUE -e TENANTID -e APPID devopsoh/proctor-container &'
 #echo "############### End of custom script ###############"


### PR DESCRIPTION
Hi,  I fix the problem of these.  However, I can reproduce `sent invalidate....` ones. For the `debconf` one related DEBIAN_FRONTEND=noninteractive.  I add this environment variables for all apt related commands.  for the `sent invalidate...`  You can refer this issue. 

https://www.digitalocean.com/community/questions/debian-9-3-droplet-issues-with-useradd

I simply add `apt-get remove unsc`. Maybe it is help to remove the issue. Could you review it and try actual environment to reproduce the issue. 

```
sent invalidate(passwd) request, exiting
sent invalidate(group) request, exiting
sent invalidate(passwd) request, exiting
sent invalidate(group) request, exiting
debconf: unable to initialize frontend: Dialog
debconf: (Dialog frontend will not work on a dumb terminal, an emacs shell buffer, or without a controlling terminal.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (This frontend requires a controlling tty.)
debconf: falling back to frontend: Teletype
dpkg-preconfigure: unable to re-open stdin:
Unable to find image 'devopsoh/proctor-container:latest' locally
latest: Pulling from devopsoh/proctor-container
```