### PR TITLE
Update provision_aks.sh

### DIFF
--- a/provision-team/jenkins/install_jenkins.sh
+++ b/provision-team/jenkins/install_jenkins.sh
@@ -489,7 +489,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install -y jq git zip azure-cli=2.0.
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce
 
 echo "############### Installing kubectl ###############"
-curl -s -LO https://storage.googleapis.com/kubernetes-release/release/v1.13.11/bin/linux/amd64/kubectl
+curl -s -LO https://storage.googleapis.com/kubernetes-release/release/v1.15.7/bin/linux/amd64/kubectl
 chmod +x ./kubectl
 sudo mv ./kubectl /usr/local/bin/kubectl
 

--- a/provision-team/provision_aks.sh
+++ b/provision-team/provision_aks.sh
@@ -129,7 +129,7 @@ fi
 echo "Creating AKS Cluster..."
 (
     set -x
-    az aks create -g $resourceGroupName -n $clusterName -l $resourceGroupLocation --node-count 3 --generate-ssh-keys -k 1.13.11 --service-principal $SP_ID --client-secret $SP_PASS
+    az aks create -g $resourceGroupName -n $clusterName -l $resourceGroupLocation --node-count 3 --generate-ssh-keys -k 1.15.7 --service-principal $SP_ID --client-secret $SP_PASS
 )
 
 if [ $? == 0 ];

--- a/provision-vm/Docker/Dockerfile
+++ b/provision-vm/Docker/Dockerfile
@@ -32,7 +32,7 @@ RUN tar -zxvf helm-v2.14.3-linux-amd64.tar.gz
 RUN mv linux-amd64/helm /usr/local/bin/helm
 
 ############### Installing kubectl ###############
-RUN curl -s -LO https://storage.googleapis.com/kubernetes-release/release/v1.13.11/bin/linux/amd64/kubectl
+RUN curl -s -LO https://storage.googleapis.com/kubernetes-release/release/v1.15.7/bin/linux/amd64/kubectl
 RUN chmod +x ./kubectl
 RUN mv ./kubectl /usr/local/bin/kubectl
 


### PR DESCRIPTION
Update AKS cluster version from 1.13.11 to 1.15.7

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fix for current cluster deployment failures. In the current master branch, v1.13.11 is being used which is not a current valid version in all regions. Updating to 1.15.7 for wider coverage across the fabric.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
[X] Unknown - emergency break/fix to get OpenHack deployments through Opsgility up and running again
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Clone repo
*  Run a full deployment
*  Verify cluster version

## What to Check
Verify that the following are valid
* AKS cluster version is 1.15.7

## Other Information
Current deployments through the Opsgility cloud sandbox are failing at a 100% rate for DevOps v1 due to the lack of availability of the older version of AKS.