### PR TITLE
Latest version returns HTTP/2 not HTTP/1.1

### DIFF
--- a/resources/polling.sh
+++ b/resources/polling.sh
@@ -43,7 +43,7 @@ fi
 
 healthcheck() {
     declare url=$1
-    result=$(curl -i $url 2>/dev/null | grep HTTP/1.1)
+    result=$(curl -i $url 2>/dev/null | grep HTTP/2)
     echo $result
 }
 
@@ -53,7 +53,7 @@ while [[ true ]]; do
    if [[ -z $result ]]; then 
       status="N/A"
    else
-      status=${result:9:3}
+      status=${result:7:3}
    fi 
    timestamp=$(date "+%Y%m%d-%H%M%S")
    if [[ -z $hasUrl ]]; then


### PR DESCRIPTION
## Purpose
This fixes an issue that does not work in the latest version of the OpenHack.
 Latest version returns HTTP/2 not HTTP/1.1

## Does this introduce a breaking change?
```
[ ] Yes
[X ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

```
./polling.sh -i https://openhackg8i5trw0userprofile.azurewebsites.net/api/healthcheck/user
```