### PR TITLE
Fix status code grabbing

### DIFF
--- a/resources/polling.sh
+++ b/resources/polling.sh
@@ -53,7 +53,7 @@ while [[ true ]]; do
    if [[ -z $result ]]; then 
       status="N/A"
    else
-      status=${result:9:3}
+      status=${result:7:3}
    fi 
    timestamp=$(date "+%Y%m%d-%H%M%S")
    if [[ -z $hasUrl ]]; then


### PR DESCRIPTION
Switching to HTTP/2 changed the output

## Purpose
#343 changed the `curl` command to use HTTP/2, but the grabbing of the HTTP status code has not been changed accordingly. The new output looks like this:

```bash
alxy@wsl:/mnt/c/Users/alxy/Downloads$ curl --http2 -i 'https://openhackjhu55qr1userjava.azurewebsites.net/api/healthcheck/user-java' 2>/dev/null
HTTP/2 200
content-type: application/json;charset=UTF-8
set-cookie: ARRAffinity=2bf37dcf7c3c486385073fd937fa4bbddc6e999397eeca2e49d8fb8904a6b286;Path=/;HttpOnly;Secure;Domain=openhackjhu55qr1userjava.azurewebsites.net
set-cookie: ARRAffinitySameSite=2bf37dcf7c3c486385073fd937fa4bbddc6e999397eeca2e49d8fb8904a6b286;Path=/;HttpOnly;SameSite=None;Secure;Domain=openhackjhu55qr1userjava.azurewebsites.net
date: Thu, 16 Dec 2021 13:26:57 GMT
```

This, the substring matching needs to be adapted, because `HTTP/1.1` is two characters more than `HTTP/2`.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check

**Old output:**
```bash
alxy@wsl:/mnt/c/Users/alxy/Downloads$ ./polling.sh 'https://openhackjhu55qr1userjava.azurewebsites.net/api/healthcheck/user-java'
 0211216-142402 | 0
```

**New output:**
```bash
alxy@wsl:/mnt/c/Users/alxy/Downloads$ ./polling.sh 'https://openhackjhu55qr1userjava.azurewebsites.net/api/healthcheck/user-java's.net/api/healthcheck/user-java' 2>/dev/null
20211216-142700 | 200
```